### PR TITLE
design: 시작 화면 안내 페이지 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'mysql:mysql-connector-java:8.0.33'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>숨 여행, 틈 | Backend</title>
+    <style>
+        * {
+          margin: 0;
+          padding: 0;
+          box-sizing: border-box;
+          font-family: "Segoe UI", "Noto Sans KR", sans-serif;
+        }
+
+        body {
+          height: 100vh;
+          background: linear-gradient(to right, #f8f9fa, #e9ecef);
+          display: flex;
+          justify-content: center;
+          align-items: center;
+        }
+
+        .container {
+          background: white;
+          padding: 3rem 4rem;
+          border-radius: 20px;
+          box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+          text-align: center;
+          max-width: 500px;
+        }
+
+        h1 {
+          font-size: 2rem;
+          color: #2c3e50;
+          margin-bottom: 1rem;
+        }
+
+        p {
+          font-size: 1rem;
+          color: #555;
+          margin-bottom: 2.5rem;
+        }
+
+        .btn {
+          display: inline-block;
+          padding: 0.75rem 1.5rem;
+          background-color: #4a90e2;
+          color: white;
+          border: none;
+          border-radius: 30px;
+          font-size: 1rem;
+          cursor: pointer;
+          text-decoration: none;
+          transition: background-color 0.3s ease;
+        }
+
+        .btn:hover {
+          background-color: #357ab7;
+        }
+
+        .logo {
+          font-size: 1.5rem;
+          font-weight: bold;
+          color: #4a90e2;
+          margin-bottom: 1.2rem;
+        }
+
+        .small {
+          font-size: 0.9rem;
+          color: #888;
+          margin-top: 2rem;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="logo">숨 여행, 틈</div>
+    <h1>백엔드 서버에 오신 걸<br /> 환영합니다!</h1>
+    <p>
+        이 페이지는 숨 여행, 틈의 백엔드 API 서버입니다.<br />
+        API 문서를 확인하려면 아래 버튼을 클릭해주세요.
+    </p>
+    <a class="btn" href="/swagger-ui/index.html">📚 Swagger API 문서 보기</a>
+    <div class="small">© 2025 숨 여행, 틈 | Backend Service</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 관련 이슈
- #6 

## 내용
- 백엔드 서버임을 안내하기 위해 /index.html 생성
- 서버 접속 시 기본 화면으로 커스텀 페이지 출력되도록 설정

## 참고사항
- 기존 Spring Security 적용으로 인해 /login으로 리다이렉트되던 문제 해결
- spring-boot-starter-security 의존성 제거하여 인증 없이 모든 요청 허용

## 관련 스크린샷
<img width="1280" height="647" alt="image" src="https://github.com/user-attachments/assets/56b8d246-11d8-42ba-8d32-0ef2e50ece51" />
