### PR TITLE
[Feat/#24] JWT 헤더 넣은 후 api 조회시 403 에러

### DIFF
--- a/install-jq-gitbash.sh
+++ b/install-jq-gitbash.sh
@@ -1,0 +1,35 @@
+set -euo pipefail
+
+# 1) 설치 경로(사용자 권한으로 안전)
+INSTALL_DIR="$HOME/bin"
+mkdir -p "$INSTALL_DIR"
+
+# 2) jq 다운로드 (64-bit용 예시 URL)
+JQ_URL="https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-win64.exe"
+echo "[INFO] Downloading jq from: $JQ_URL"
+curl -L -o "$INSTALL_DIR/jq.exe" "$JQ_URL"
+
+# 3) 실행 권한 부여
+chmod +x "$INSTALL_DIR/jq.exe"
+
+# 4) PATH 등록 (중복 방지)
+PROFILE="$HOME/.bashrc"
+if ! grep -q 'export PATH="$HOME/bin:$PATH"' "$PROFILE" 2>/dev/null; then
+  echo 'export PATH="$HOME/bin:$PATH"' >> "$PROFILE"
+  ADDED=1
+else
+  ADDED=0
+fi
+
+echo
+echo "✅ jq installed: $INSTALL_DIR/jq.exe"
+echo "   Version check (current shell):"
+export PATH="$HOME/bin:$PATH"
+"$INSTALL_DIR/jq.exe" --version || true
+
+if [ "$ADDED" -eq 1 ]; then
+  echo
+  echo "ℹ️  PATH가 ~/.bashrc에 추가되었습니다. 새 Git Bash를 열면 자동 적용됩니다."
+  echo "    (현재 세션에는 아래 명령으로 즉시 반영됨)"
+  echo '    export PATH="$HOME/bin:$PATH"'
+fi

--- a/src/main/java/com/comma/soomteum/config/SecurityConfig.java
+++ b/src/main/java/com/comma/soomteum/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.comma.soomteum.domain.auth.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -30,11 +31,14 @@ public class SecurityConfig {
                 .httpBasic(httpBasic -> httpBasic.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
-                                "/api/auth/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/api/auth/**","/error").permitAll()
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()  // 프리플라이트 허용
+                        .requestMatchers(HttpMethod.GET, "/api/kor/**").hasAuthority("ROLE_USER")
+                        .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()));
+
 
         return http.build();
     }

--- a/src/main/java/com/comma/soomteum/config/SecurityConfig.java
+++ b/src/main/java/com/comma/soomteum/config/SecurityConfig.java
@@ -9,30 +9,77 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 @Configuration
-@EnableWebSecurity
+@EnableWebSecurity(debug = false)
 @RequiredArgsConstructor
 public class SecurityConfig {
+
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
-                .formLogin(formLogin -> formLogin.disable())
-                .httpBasic(httpBasic -> httpBasic.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
-                                "/api/auth/**").permitAll()
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers(
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/api/auth/**"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
+                // 필터 순서
+                // 1) X-Internal-Token → Authorization 주입
+                .addFilterBefore(new InternalTokenHeaderMappingFilter(), UsernamePasswordAuthenticationFilter.class)
+                // 2) JWT 인증
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()));
+                // X-Frame-Options sameOrigin 유지
+                .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()));
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOrigins(Arrays.asList(
+                "http://localhost:8080"
+        ));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }
 

--- a/src/main/java/com/comma/soomteum/config/SecurityConfig.java
+++ b/src/main/java/com/comma/soomteum/config/SecurityConfig.java
@@ -15,26 +15,10 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.Arrays;
-
 @Configuration
 @EnableWebSecurity(debug = false)
 @RequiredArgsConstructor
 public class SecurityConfig {
-
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
@@ -42,26 +26,15 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
-                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .formLogin(form -> form.disable())
-                .httpBasic(basic -> basic.disable())
+                .formLogin(formLogin -> formLogin.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers(
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/api/auth/**"
-                        ).permitAll()
-                        .anyRequest().authenticated()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
+                                "/api/auth/**").permitAll()
                 )
-                // 필터 순서
-                // 1) X-Internal-Token → Authorization 주입
-                .addFilterBefore(new InternalTokenHeaderMappingFilter(), UsernamePasswordAuthenticationFilter.class)
-                // 2) JWT 인증
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                // X-Frame-Options sameOrigin 유지
-                .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()));
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()));
 
         return http.build();
     }
@@ -73,12 +46,14 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(Arrays.asList(
                 "http://localhost:8080"
         ));
+
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
+
         return source;
     }
 }

--- a/src/main/java/com/comma/soomteum/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/comma/soomteum/domain/auth/JwtAuthenticationFilter.java
@@ -5,6 +5,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -13,24 +15,92 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenManager jwtTokenManager;
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+
+    /**
+     * 기본값(true)을 뒤집어서, 비동기 디스패치 시에도 필터가 실행되도록 합니다.
+     * (초기 요청과 async 재디스패치 모두에서 인증 상태를 보장)
+     */
+    @Override
+    protected boolean shouldNotFilterAsyncDispatch() {
+        return false;
+    }
+
+    /**
+     * 에러 디스패치에서도 토큰을 읽어 컨텍스트를 세팅할 수 있게 합니다.
+     */
+    @Override
+    protected boolean shouldNotFilterErrorDispatch() {
+        return false;
+    }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
-        String token = resolveToken(request);
-        if (StringUtils.hasText(token) && jwtTokenManager.validateToken(token)) {
-            Authentication authentication = jwtTokenManager.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws IOException, ServletException {
+
+        // 이미 다른 필터/디스패치에서 인증된 경우 중복 작업을 피함
+        var context = SecurityContextHolder.getContext();
+        var existingAuth = context.getAuthentication();
+        if (existingAuth != null && existingAuth.isAuthenticated()) {
+            if (log.isDebugEnabled()) {
+                log.debug("[JWT] Skip auth: already authenticated principal={}, dispatchType={}, thread={}",
+                        existingAuth.getName(), request.getDispatcherType(), Thread.currentThread().getName());
+            }
+            filterChain.doFilter(request, response);
+            return;
         }
+
+        String token = resolveToken(request);
+
+        if (!StringUtils.hasText(token)) {
+            if (log.isDebugEnabled()) {
+                log.debug("[JWT] No token. uri={}, method={}, dispatchType={}, thread={}",
+                        request.getRequestURI(), request.getMethod(),
+                        request.getDispatcherType(), Thread.currentThread().getName());
+            }
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (jwtTokenManager.validateToken(token)) {
+            Authentication authentication = jwtTokenManager.getAuthentication(token);
+            if (authentication != null) {
+                context.setAuthentication(authentication);
+                if (log.isDebugEnabled()) {
+                    log.debug("[JWT] Authenticated principal={}, authorities={}, uri={}, dispatchType={}, thread={}",
+                            authentication.getName(), authentication.getAuthorities(),
+                            request.getRequestURI(), request.getDispatcherType(), Thread.currentThread().getName());
+                }
+            } else {
+                if (log.isWarnEnabled()) {
+                    log.warn("[JWT] getAuthentication returned null. uri={}, dispatchType={}",
+                            request.getRequestURI(), request.getDispatcherType());
+                }
+            }
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("[JWT] Invalid token. uri={}, dispatchType={}, thread={}",
+                        request.getRequestURI(), request.getDispatcherType(), Thread.currentThread().getName());
+            }
+        }
+
         filterChain.doFilter(request, response);
     }
 
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
+        // 헤더 로깅은 디버그에서만
+        if (log.isTraceEnabled()) {
+            log.trace("[JWT] Authorization header present? {} (uri={})",
+                    (bearerToken != null), request.getRequestURI());
+        }
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }

--- a/src/main/java/com/comma/soomteum/domain/auth/JwtTokenManager.java
+++ b/src/main/java/com/comma/soomteum/domain/auth/JwtTokenManager.java
@@ -16,6 +16,10 @@ import org.springframework.util.StringUtils;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.security.Key;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -51,21 +55,25 @@ public class JwtTokenManager {
 
 
     public TokenDto generateTokens(User user) {
-        long now = (new Date()).getTime();
-        Date accessTokenExpiresIn = new Date(now + this.accessTokenExpirationMilliseconds);
+        Instant now = Instant.now();
+        Instant accessExp = now.plusMillis(accessTokenExpirationMilliseconds);
+        Instant refreshExp = now.plusMillis(refreshTokenExpirationMilliseconds);
+
         String subject = String.valueOf(user.getUserId());
         String authorities = "ROLE_USER";
 
         String accessToken = Jwts.builder()
                 .setSubject(subject)
                 .claim(AUTHORITIES_KEY, authorities)
-                .setExpiration(accessTokenExpiresIn)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(accessExp))
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();
 
         String refreshToken = Jwts.builder()
                 .setSubject(subject)
-                .setExpiration(new Date(now + this.refreshTokenExpirationMilliseconds))
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(refreshExp))
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();
 
@@ -73,6 +81,9 @@ public class JwtTokenManager {
                 .grantType(BEARER_TYPE)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .issuedAt(now)
+                .accessExpiresAt(accessExp)
+                .refreshExpiresAt(refreshExp)
                 .build();
     }
 
@@ -95,6 +106,9 @@ public class JwtTokenManager {
             log.info("잘못된 JWT 서명입니다.");
         } catch (ExpiredJwtException e) {
             log.info("만료된 JWT 토큰입니다.");
+            log.info("Server Current Time: {}", new java.util.Date());
+            log.info("Token Expiration Time: {}", e.getClaims().getExpiration());
+            log.info("Token Issued At: {}", e.getClaims().getIssuedAt());
         } catch (UnsupportedJwtException e) {
             log.info("지원되지 않는 JWT 토큰입니다.");
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/comma/soomteum/domain/auth/service/AuthService.java
+++ b/src/main/java/com/comma/soomteum/domain/auth/service/AuthService.java
@@ -11,9 +11,11 @@ import com.comma.soomteum.domain.user.repository.UserRepository;
 import com.comma.soomteum.global.response.CustomException;
 import com.comma.soomteum.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
@@ -25,39 +27,39 @@ public class AuthService {
     private final TokenRepository tokenRepository;
     private final JwtTokenManager jwtTokenManager;
 
+
     @Transactional
     public LoginResponseDto socialLogin(String providerId, String email) {
-        // 1) providerId로 user 조회 또는 신규 생성
-        Optional<User> userOptional = userRepository.findByProviderId(providerId);
+        User user = userRepository.findByProviderId(providerId)
+                .orElseGet(() -> userRepository.save(
+                        User.builder()
+                                .providerId(providerId)
+                                .nickname("유저" + providerId)
+                                .email(email)
+                                .isActive(true)
+                                .build()
+                ));
 
-        boolean isNewUser = userOptional.isEmpty();
+        boolean isNewUser = user.getCreatedAt() != null &&
+                user.getUpdatedAt() != null &&
+                user.getCreatedAt().equals(user.getUpdatedAt());
 
-        User user = userOptional.orElseGet(() -> userRepository.save(
-                User.builder()
-                        .providerId(providerId)
-                        .nickname("유저" + providerId)
-                        .email(email)
-                        .isActive(true)
-                        .build()
-        ));
-
-
-        // 2) JWT 생성
         TokenDto tokenDto = jwtTokenManager.generateTokens(user);
 
-        // 3) Token 엔티티로 저장
+        // Instant -> LocalDateTime 변환 (서버 표준 Zone 사용)
+        ZoneId zone = ZoneId.systemDefault();
         Token token = Token.builder()
                 .user(user)
                 .grantType(tokenDto.getGrantType())
                 .accessToken(tokenDto.getAccessToken())
-                .accessExpiresAt(LocalDateTime.now().plus(jwtTokenManager.getAccessExpiration(), ChronoUnit.MILLIS))
+                .accessExpiresAt(LocalDateTime.ofInstant(tokenDto.getAccessExpiresAt(), zone))
                 .refreshToken(tokenDto.getRefreshToken())
-                .refreshExpiresAt(LocalDateTime.now().plus(jwtTokenManager.getRefreshExpiration(), ChronoUnit.MILLIS))
-                .issuedAt(LocalDateTime.now())
+                .refreshExpiresAt(LocalDateTime.ofInstant(tokenDto.getRefreshExpiresAt(), zone))
+                .issuedAt(LocalDateTime.ofInstant(tokenDto.getIssuedAt(), zone))
                 .build();
+
         tokenRepository.save(token);
 
-        // 4) 응답
         return LoginResponseDto.builder()
                 .grantType(tokenDto.getGrantType())
                 .accessToken(tokenDto.getAccessToken())
@@ -66,26 +68,25 @@ public class AuthService {
                 .build();
     }
 
+
     @Transactional
     public TokenDto reissue(AuthTokenRequestDto requestDto) {
-        // 1) DB에서 refreshToken 조회
         Token token = tokenRepository.findByRefreshToken(requestDto.getRefreshToken())
                 .orElseThrow(() -> new CustomException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
 
-        // 2) 리프레시 토큰 검증
         if (!jwtTokenManager.validateToken(token.getRefreshToken())) {
             throw new CustomException(ErrorCode.REFRESH_TOKEN_MISMATCH);
         }
 
-        // 3) 새 JWT 생성
         TokenDto newTokens = jwtTokenManager.generateTokens(token.getUser());
 
-        // 4) refresh 토큰 만료 시각 계산
-        LocalDateTime refreshExpiresAt = LocalDateTime.now()
-                .plus(jwtTokenManager.getRefreshExpiration(), ChronoUnit.MILLIS);
-
-        // 5) Token 엔티티 업데이트
-        token.updateRefreshToken(newTokens.getRefreshToken(), refreshExpiresAt);
+        ZoneId zone = ZoneId.systemDefault();
+        token.updateTokens(
+                newTokens.getAccessToken(),
+                LocalDateTime.ofInstant(newTokens.getAccessExpiresAt(), zone),
+                newTokens.getRefreshToken(),
+                LocalDateTime.ofInstant(newTokens.getRefreshExpiresAt(), zone)
+        );
 
         return newTokens;
     }

--- a/src/main/java/com/comma/soomteum/domain/place/Controller/KorService2Controller.java
+++ b/src/main/java/com/comma/soomteum/domain/place/Controller/KorService2Controller.java
@@ -42,8 +42,6 @@ public class KorService2Controller {
     public Mono<KorService2Response> locationBasedList(
             @ParameterObject TourApiRequestDto.LocationBasedList2 req
     ) {
-        // DTO 내부의 pageNoOrDefault, rowsOrDefault, arrangeOrDefault 등을
-        // 서비스에서 사용 가능 (컨트롤러에서는 그대로 전달)
         return korService2Service.locationBasedList(req);
     }
 }

--- a/src/main/java/com/comma/soomteum/domain/token/dto/TokenDto.java
+++ b/src/main/java/com/comma/soomteum/domain/token/dto/TokenDto.java
@@ -1,20 +1,21 @@
 package com.comma.soomteum.domain.token.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
+
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class TokenDto {
     private String grantType;
     private String accessToken;
     private String refreshToken;
-
-    @Builder
-    public TokenDto(String grantType, String accessToken, String refreshToken) {
-        this.grantType = grantType;
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
-    }
+    private Instant issuedAt;
+    private Instant accessExpiresAt;
+    private Instant refreshExpiresAt;
 }

--- a/src/main/java/com/comma/soomteum/domain/token/entity/Token.java
+++ b/src/main/java/com/comma/soomteum/domain/token/entity/Token.java
@@ -43,9 +43,11 @@ public class Token extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    public void updateRefreshToken(String refreshToken, LocalDateTime expiresAt) {
+    public void updateTokens(String accessToken, LocalDateTime accessExpiresAt, String refreshToken, LocalDateTime refreshExpiresAt) {
+        this.accessToken = accessToken;
+        this.accessExpiresAt = accessExpiresAt;
         this.refreshToken = refreshToken;
-        this.refreshExpiresAt = expiresAt;
+        this.refreshExpiresAt = refreshExpiresAt;
     }
 
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #24


## 🛠 문제사항
<!-- 구체적인 작업 내용을 적어주세요 -->
- 한 요청에서 shouldNotFilter 로그가 2번 출력 → 필터가 한 요청에 2회 호출됨. 
- -> 이는 비동기 처리로 인해 동일 요청이 여러 스레드에서 이어 처리되고 있음


## 해결방안
- async/error 디스패치에서도 필터가 동작하도록 오버라이드
- 이미 컨텍스트에 인증이 있으면 중복 인증 스킵
