### PR TITLE
[feat/#29] 카카오 콜백 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,28 +24,48 @@ repositories {
 }
 
 dependencies {
+	// =============================
+	// Jackson BOM으로 버전 통일 (2.19.2)
+	// =============================
+	implementation platform('com.fasterxml.jackson:jackson-bom:2.19.2')
+
+	// 필요한 Jackson 모듈 (버전 명시 X, BOM 따라감)
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+	implementation 'com.fasterxml.jackson.core:jackson-annotations'
+	implementation 'com.fasterxml.jackson.core:jackson-core'
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+
+	// Spring Boot 기본
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'mysql:mysql-connector-java:8.0.33'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	testImplementation 'io.projectreactor:reactor-test'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// DB
+	implementation 'mysql:mysql-connector-java:8.0.33'
+
+	// OpenAPI (Swagger)
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// Config Processor
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
+	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+	testImplementation 'io.projectreactor:reactor-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.19.2' // xml
-
-	// JWT API
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-
-	// JWT 구현체 및 시리얼라이저 (jackson 기반)
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // or jjwt-gson if using gson
 }
+
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2' // xml
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.19.2' // xml
 
 	// JWT API
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/comma/soomteum/config/SwaggerConfig.java
+++ b/src/main/java/com/comma/soomteum/config/SwaggerConfig.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -70,7 +71,7 @@ public class SwaggerConfig {
 
     // KOR Service2 그룹
     @Bean
-    GroupedOpenApi korGroup(OpenApiCustomizer commonErrorResponses) {
+    GroupedOpenApi korGroup(@Qualifier("commonErrorResponses") OpenApiCustomizer commonErrorResponses) {
         return GroupedOpenApi.builder()
                 .group("KOR Service2")
                 .pathsToMatch("/api/kor/**")
@@ -80,7 +81,7 @@ public class SwaggerConfig {
 
     // Auth(카카오) 그룹
     @Bean
-    GroupedOpenApi authGroup(OpenApiCustomizer commonErrorResponses) {
+    GroupedOpenApi authGroup(@Qualifier("commonErrorResponses") OpenApiCustomizer commonErrorResponses) {
         return GroupedOpenApi.builder()
                 .group("Auth")
                 .pathsToMatch("/api/auth/**")

--- a/src/main/java/com/comma/soomteum/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/comma/soomteum/domain/auth/controller/AuthController.java
@@ -8,10 +8,12 @@ import com.comma.soomteum.domain.auth.service.KakaoAuthService;
 import com.comma.soomteum.domain.token.dto.TokenDto;
 import com.comma.soomteum.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -90,4 +92,27 @@ public class AuthController {
         TokenDto tokenDto = authService.reissue(requestDto);
         return ApiResponse.ok(tokenDto);
     }
+
+    @Operation(
+            summary = "카카오 로그인 콜백",
+            description = """
+            카카오 OAuth 인가 코드를 받아 앱 로그인/회원가입을 처리합니다.
+            - 프론트엔드에서 카카오 인가 코드를 받아 이 API로 전달합니다.
+            - 성공 시 앱용 액세스/리프레시 토큰 등을 반환합니다.
+            """,
+            security = {}
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", description = "로그인 성공",
+            content = @Content(schema = @Schema(implementation = LoginResponseDto.class))
+    )
+    @GetMapping("/kakao/callback")
+    public ApiResponse<LoginResponseDto> kakaoCallback(
+            @Parameter(description = "카카오 인가 코드", required = true, example = "sample_auth_code_here")
+            @RequestParam("code") String code
+    ) {
+        LoginResponseDto responseDto = kakaoAuthService.loginWithCode(code);
+        return ApiResponse.ok(responseDto);
+    }
+
 }

--- a/src/main/java/com/comma/soomteum/domain/auth/dto/DevLoginRequestDto.java
+++ b/src/main/java/com/comma/soomteum/domain/auth/dto/DevLoginRequestDto.java
@@ -1,0 +1,10 @@
+package com.comma.soomteum.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DevLoginRequestDto {
+    private Long userId;
+}

--- a/src/main/java/com/comma/soomteum/domain/auth/dto/KakaoTokenResponseDto.java
+++ b/src/main/java/com/comma/soomteum/domain/auth/dto/KakaoTokenResponseDto.java
@@ -1,0 +1,28 @@
+package com.comma.soomteum.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoTokenResponseDto {
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    private Integer refreshTokenExpiresIn;
+
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/src/main/java/com/comma/soomteum/domain/auth/service/AuthService.java
+++ b/src/main/java/com/comma/soomteum/domain/auth/service/AuthService.java
@@ -44,6 +44,19 @@ public class AuthService {
                 user.getUpdatedAt() != null &&
                 user.getCreatedAt().equals(user.getUpdatedAt());
 
+        return issueTokensAndSave(user, isNewUser);
+    }
+
+    @Transactional
+    public LoginResponseDto devLogin(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 개발자 로그인은 항상 기존 유저로 간주
+        return issueTokensAndSave(user, false);
+    }
+
+    private LoginResponseDto issueTokensAndSave(User user, boolean isNewUser) {
         TokenDto tokenDto = jwtTokenManager.generateTokens(user);
 
         // Instant -> LocalDateTime 변환 (서버 표준 Zone 사용)

--- a/src/main/java/com/comma/soomteum/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/comma/soomteum/domain/auth/service/KakaoAuthService.java
@@ -1,11 +1,15 @@
 package com.comma.soomteum.domain.auth.service;
 
 
+import com.comma.soomteum.domain.auth.dto.KakaoTokenResponseDto;
 import com.comma.soomteum.domain.auth.dto.KakaoUserResponseDto;
 import com.comma.soomteum.domain.auth.dto.LoginResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -16,8 +20,23 @@ public class KakaoAuthService {
     private final AuthService authService;
     private final WebClient webClient = WebClient.create();
 
+    // TODO: Move these to a configuration file (e.g., application.yml)
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri:https://kauth.kakao.com/oauth/token}")
+    private String tokenUri;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id:YOUR_CLIENT_ID}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri:http://localhost:8080/api/auth/kakao/callback}")
+    private String redirectUri;
+
     @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
     private String userInfoUri;
+
+    public LoginResponseDto loginWithCode(String accessCode) {
+        String kakaoAccessToken = getKakaoAccessToken(accessCode).block();
+        return processKakaoLogin(kakaoAccessToken);
+    }
 
     public LoginResponseDto processKakaoLogin(String kakaoAccessToken) {
         // 1. 전달받은 액세스 토큰으로 사용자 정보 요청
@@ -28,6 +47,22 @@ public class KakaoAuthService {
         String email = userResponse.getKakaoAccount().getEmail();
 
         return authService.socialLogin(providerId, email);
+    }
+
+    private Mono<String> getKakaoAccessToken(String accessCode) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("grant_type", "authorization_code");
+        formData.add("client_id", clientId);
+        formData.add("redirect_uri", redirectUri);
+        formData.add("code", accessCode);
+
+        return webClient.post()
+                .uri(tokenUri)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .bodyValue(formData)
+                .retrieve()
+                .bodyToMono(KakaoTokenResponseDto.class)
+                .map(KakaoTokenResponseDto::getAccessToken);
     }
 
     private Mono<KakaoUserResponseDto> getKakaoUserInfo(String accessToken) {

--- a/src/main/java/com/comma/soomteum/global/response/ErrorCode.java
+++ b/src/main/java/com/comma/soomteum/global/response/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     REFRESH_TOKEN_NOT_FOUND(401_011, HttpStatus.UNAUTHORIZED, "저장된 리프레시 토큰이 존재하지 않습니다."),
     REFRESH_TOKEN_MISMATCH(401_009, HttpStatus.UNAUTHORIZED, "저장된 리프레시 토큰과 일치하지 않습니다."),
     EXPIRED_REFRESH_TOKEN(401_010, HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
+    DEV_TOKEN_UNAUTHORIZED(401_012, HttpStatus.UNAUTHORIZED, "유효하지 않은 개발자 토큰입니다."),
 
 
     // ========================


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #29

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
   - 카카오 소셜 로그인 콜백 기능 구현                                                                                                          
     - 사용자가 카카오 동의 화면을 거친 후 리디렉션되는 콜백(callback)을 처리하는 API를 개발했습니다.                                           
     - 프론트엔드에서 전달하는 카카오 인가 코드를 받아, 이를 카카오 액세스 토큰으로 교환합니다.                                                 
     - 발급받은 토큰으로 사용자 정보를 조회하여 서비스에 자동으로 회원가입 또는 로그인 처리하고, 서비스 전용 JWT 토큰을 발급합니다.   
     - 
## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
   - `AuthController` 수정                                                                                                                      
     - GET /api/auth/kakao/callback 엔드포인트 추가                                                                                             
     - 카카오 인가 코드를 code 쿼리 파라미터로 받아 처리                                                                                        
     - Swagger 문서 업데이트                                                                                                                    
                                                                                                                                                
   - `KakaoAuthService` 수정                                                                                                                    
     - loginWithCode 메서드 추가: 인가 코드를 받아 카카오 토큰 발급 및 로그인 처리 흐름을 총괄                                                  
     - getKakaoAccessToken 메서드 추가: WebClient를 사용하여 카카오 인증 서버에 인가 코드를 보내고 액세스 토큰을 받아오는 로직 구현             
     - application.yml 또는 환경변수에서 카카오 관련 설정(client-id, redirect-uri 등)을 주입받도록 변경                                         
                                                                                                                                                
   - `KakaoTokenResponseDto` 추가                                                                                                               
     - 카카오 토큰 발급 API의 응답을 매핑하기 위한 DTO(Data Transfer Object) 생성                                                               
                                                                                                                                                
   - `build.gradle` 의존성 버전 업데이트
     - jackson-dataformat-xml 라이브러리 버전을 2.15.2에서 2.19.2로 업데이트


- (https://kauth.kakao.com/oauth/authorize?client_id=1459fb129ebbdd09a8b45cee027c6d72&redirect_uri=http://localhost:8080/api/auth/kakao/callback&response_type=code) 



