### PR TITLE
[refactor/#32] 도메인 리팩토링

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/place/config/TourApiConfig.java
+++ b/src/main/java/com/comma/soomteum/domain/place/config/TourApiConfig.java
@@ -1,4 +1,4 @@
-package com.comma.soomteum.domain.place.Config;
+package com.comma.soomteum.domain.place.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/comma/soomteum/domain/place/config/TourApiProperties.java
+++ b/src/main/java/com/comma/soomteum/domain/place/config/TourApiProperties.java
@@ -1,4 +1,4 @@
-package com.comma.soomteum.domain.place.Config;
+package com.comma.soomteum.domain.place.config;
 
 
 import lombok.*;

--- a/src/main/java/com/comma/soomteum/domain/place/controller/KorService2Controller.java
+++ b/src/main/java/com/comma/soomteum/domain/place/controller/KorService2Controller.java
@@ -1,10 +1,10 @@
-package com.comma.soomteum.domain.place.Controller;
+package com.comma.soomteum.domain.place.controller;
 
 
-import com.comma.soomteum.domain.place.Dto.TourApiRequestDto;
-import com.comma.soomteum.domain.place.Dto.KorService2Response;
-import com.comma.soomteum.domain.place.Service.KorAreaService;
-import com.comma.soomteum.domain.place.Service.KorLocationService;
+import com.comma.soomteum.domain.place.dto.TourApiRequestDto;
+import com.comma.soomteum.domain.place.dto.KorService2Response;
+import com.comma.soomteum.domain.place.service.KorAreaService;
+import com.comma.soomteum.domain.place.service.KorLocationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/comma/soomteum/domain/place/dto/KorService2Response.java
+++ b/src/main/java/com/comma/soomteum/domain/place/dto/KorService2Response.java
@@ -1,4 +1,4 @@
-package com.comma.soomteum.domain.place.Dto;
+package com.comma.soomteum.domain.place.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonRootName;

--- a/src/main/java/com/comma/soomteum/domain/place/dto/TourApiErrorResponse.java
+++ b/src/main/java/com/comma/soomteum/domain/place/dto/TourApiErrorResponse.java
@@ -1,4 +1,4 @@
-package com.comma.soomteum.domain.place.Dto;
+package com.comma.soomteum.domain.place.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/src/main/java/com/comma/soomteum/domain/place/dto/TourApiRequestDto.java
+++ b/src/main/java/com/comma/soomteum/domain/place/dto/TourApiRequestDto.java
@@ -1,4 +1,4 @@
-package com.comma.soomteum.domain.place.Dto;
+package com.comma.soomteum.domain.place.dto;
 
 import lombok.*;
 

--- a/src/main/java/com/comma/soomteum/domain/place/entity/Place.java
+++ b/src/main/java/com/comma/soomteum/domain/place/entity/Place.java
@@ -6,6 +6,8 @@ import com.comma.soomteum.domain.theme.entity.Theme;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
+
 @Entity
 @Table(name = "place")
 @Getter
@@ -20,6 +22,12 @@ public class Place extends BaseEntity {
 
     @Column(length = 255, nullable = false)
     private String contentId;
+
+    @Column(length = 100, nullable = false)
+    private BigDecimal cnctrLevel;
+
+    @Column(nullable = false)
+    private Long likeCount;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "region_id", nullable = false)

--- a/src/main/java/com/comma/soomteum/domain/place/service/KorApiCaller.java
+++ b/src/main/java/com/comma/soomteum/domain/place/service/KorApiCaller.java
@@ -1,7 +1,7 @@
-package com.comma.soomteum.domain.place.Service;
+package com.comma.soomteum.domain.place.service;
 
-import com.comma.soomteum.domain.place.Config.TourApiProperties;
-import com.comma.soomteum.domain.place.Dto.TourApiErrorResponse;
+import com.comma.soomteum.domain.place.config.TourApiProperties;
+import com.comma.soomteum.domain.place.dto.TourApiErrorResponse;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;

--- a/src/main/java/com/comma/soomteum/domain/place/service/KorAreaService.java
+++ b/src/main/java/com/comma/soomteum/domain/place/service/KorAreaService.java
@@ -1,12 +1,12 @@
-package com.comma.soomteum.domain.place.Service;
+package com.comma.soomteum.domain.place.service;
 
-import com.comma.soomteum.domain.place.Dto.KorService2Response;
-import com.comma.soomteum.domain.place.Dto.TourApiRequestDto;
+import com.comma.soomteum.domain.place.dto.KorService2Response;
+import com.comma.soomteum.domain.place.dto.TourApiRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
-import static com.comma.soomteum.domain.place.Service.KorApiCaller.qpIfPresent;
+import static com.comma.soomteum.domain.place.service.KorApiCaller.qpIfPresent;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/comma/soomteum/domain/place/service/KorLocationService.java
+++ b/src/main/java/com/comma/soomteum/domain/place/service/KorLocationService.java
@@ -1,12 +1,12 @@
-package com.comma.soomteum.domain.place.Service;
+package com.comma.soomteum.domain.place.service;
 
-import com.comma.soomteum.domain.place.Dto.KorService2Response;
-import com.comma.soomteum.domain.place.Dto.TourApiRequestDto;
+import com.comma.soomteum.domain.place.dto.KorService2Response;
+import com.comma.soomteum.domain.place.dto.TourApiRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
-import static com.comma.soomteum.domain.place.Service.KorApiCaller.qpIfPresent;
+import static com.comma.soomteum.domain.place.service.KorApiCaller.qpIfPresent;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/comma/soomteum/domain/region/entity/Region.java
+++ b/src/main/java/com/comma/soomteum/domain/region/entity/Region.java
@@ -16,6 +16,19 @@ public class Region extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long regionId;
 
-    @Column(length = 100, nullable = false)
+    @Column(length = 20, nullable = false)
     private String name;
+
+    @Column(name = "kor_area_code", nullable = false)
+    private int korAreaCode;   // 국문 관광 서비스 지역코드
+
+    @Column(name = "kor_sigungu_code", nullable = false)
+    private int korSigunguCode;   // 국문 관광 서비스 시군구 코드
+
+    @Column(name = "cnctr_area_code", nullable = false)
+    private int cnctrAreaCode;   // 집중률 지역 코드
+
+    @Column(name = "cnctr_sigungu_code", nullable = false)
+    private int cnctrSigunguCode;   // 집중률 시군구 코드
+
 }

--- a/src/main/java/com/comma/soomteum/domain/region/entity/Region.java
+++ b/src/main/java/com/comma/soomteum/domain/region/entity/Region.java
@@ -16,12 +16,6 @@ public class Region extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long regionId;
 
-    @Column(nullable = false)
-    private Integer areaCode;
-
-    @Column(nullable = false)
-    private Integer sigunguCode;
-
     @Column(length = 100, nullable = false)
     private String name;
 }

--- a/src/main/java/com/comma/soomteum/domain/userPlace/entity/UserPlace.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/entity/UserPlace.java
@@ -1,4 +1,4 @@
-package com.comma.soomteum.domain.userattraction.entity;
+package com.comma.soomteum.domain.userPlace.entity;
 
 import com.comma.soomteum.domain.BaseEntity;
 import com.comma.soomteum.domain.place.entity.Place;
@@ -12,15 +12,17 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class UserAttraction extends BaseEntity {
+public class UserPlace extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userContentId;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private UserAttractionType type;
+    @Column(name = "save", nullable = false)
+    private boolean save;
+
+    @Column(name = "like", nullable = false)
+    private boolean like;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/comma/soomteum/domain/userPlace/entity/UserPlace.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/entity/UserPlace.java
@@ -3,6 +3,7 @@ package com.comma.soomteum.domain.userPlace.entity;
 import com.comma.soomteum.domain.BaseEntity;
 import com.comma.soomteum.domain.place.entity.Place;
 import com.comma.soomteum.domain.user.entity.User;
+import com.comma.soomteum.domain.userPlace.enums.UserActionType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,11 +19,9 @@ public class UserPlace extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userContentId;
 
-    @Column(name = "save", nullable = false)
-    private boolean save;
-
-    @Column(name = "like", nullable = false)
-    private boolean like;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserActionType type;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/comma/soomteum/domain/userPlace/enums/UserActionType.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/enums/UserActionType.java
@@ -1,0 +1,5 @@
+package com.comma.soomteum.domain.userPlace.enums;
+
+public enum UserActionType {
+    SAVE, LIKE
+}

--- a/src/main/java/com/comma/soomteum/domain/userattraction/entity/UserAttractionType.java
+++ b/src/main/java/com/comma/soomteum/domain/userattraction/entity/UserAttractionType.java
@@ -1,5 +1,0 @@
-package com.comma.soomteum.domain.userattraction.entity;
-
-public enum UserAttractionType {
-    LIKE, SAVE
-}

--- a/src/main/java/com/comma/soomteum/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/comma/soomteum/global/exception/GlobalExceptionHandler.java
@@ -41,9 +41,9 @@ public class GlobalExceptionHandler {
     }
 
     // 업스트림 예외 매핑
-    @ExceptionHandler(com.comma.soomteum.domain.place.Service.KorApiCaller.Upstream4xxException.class)
+    @ExceptionHandler(com.comma.soomteum.domain.place.service.KorApiCaller.Upstream4xxException.class)
     public ResponseEntity<ApiResponse<?>> handleUpstream4xx(
-            com.comma.soomteum.domain.place.Service.KorApiCaller.Upstream4xxException ex,
+            com.comma.soomteum.domain.place.service.KorApiCaller.Upstream4xxException ex,
             HttpServletRequest request
     ) {
         var custom = new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, ex.getMessage());
@@ -51,9 +51,9 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(custom, request.getRequestURI()));
     }
 
-    @ExceptionHandler(com.comma.soomteum.domain.place.Service.KorApiCaller.Upstream5xxException.class)
+    @ExceptionHandler(com.comma.soomteum.domain.place.service.KorApiCaller.Upstream5xxException.class)
     public ResponseEntity<ApiResponse<?>> handleUpstream5xx(
-            com.comma.soomteum.domain.place.Service.KorApiCaller.Upstream5xxException ex,
+            com.comma.soomteum.domain.place.service.KorApiCaller.Upstream5xxException ex,
             HttpServletRequest request
     ) {
         var custom = new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, ex.getMessage());


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #32

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
   - Entity 및 폴더 구조 리팩토링

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
   - 폴더 구조 변경
       - 도메인 내 폴더명을 파스칼 케이스에서 카멜 케이스로 변경하여 소문자로 통일했습니다. (e.g., domain/place/Controller ->
         domain/place/controller)
       - 변경된 폴더 구조에 맞춰 관련 파일들의 package 및 import 구문을 수정했습니다.

   - Entity 수정
       - Place                                                                                                                                 
           - cnctrLevel (장소 혼잡도) 필드를 BigDecimal 타입으로 추가했습니다.                                                                 
           - likeCount (좋아요 수) 필드를 Long 타입으로 추가했습니다. 
       - Region
           - name 컬럼의 길이를 20으로 변경했습니다.
           - 관광 정보 서비스 및 집중도 서비스에서 활용할 지역/시군구 코드 컬럼을 추가했습니다. (kor_area_code, kor_sigungu_code,
             cnctr_area_code, cnctr_sigungu_code)
       - UserPlace (구 UserAttraction)
           - UserAttraction Entity의 이름과 파일명을 UserPlace로 변경했습니다.
           - 기존의 UserAttractionType Enum을 사용하는 대신, save(저장)와 like(좋아요) 상태를 나타내는 boolean 타입의 두 필드를 추가했습니다.
           - 이에 따라 UserAttractionType Enum 파일은 삭제되었습니다.

