### PR TITLE
[Fix/#31] EC2 리전 재배포

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,62 +1,61 @@
-# .github/workflows/deploy.yml
-name: CI/CD Deploy to EC2
-
-# 이벤트 트리거: dev 브랜치에 push 발생 시 실행
+name: deploy
 on:
-  pull_request:
-    branches:
-      - dev
   push:
-    branches:
-      - dev
+    branches: [ dev ]
+  workflow_dispatch:
 
 jobs:
-  build-push-deploy:
-    name: Build, Push Docker Image and Deploy to EC2
+  build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    concurrency:
+      group: deploy-soomteum
+      cancel-in-progress: true
 
     steps:
-      # Checkout repository
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      # Set up JDK 17 (Spring 프로젝트용)
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
+      # 1) OIDC로 AWS 자격 구성
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
-      # Add Permission
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+      # 2) ECR 로그인
+      - name: Login to ECR
+        uses: aws-actions/amazon-ecr-login@v2
 
-      # Build with Gradle
-      - name: Build with Gradle
-        run: ./gradlew build -x test
-
-      # Log in to DockerHub
-      - name: Log in to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      # Build Docker image
-      - name: Build Docker image
-        run: docker build -t lilloo04/soomteum:latest .
-
-      # Push Docker image
-      - name: Push Docker image
-        run: docker push lilloo04/soomteum:latest
-
-      # Set up SSH agent
-      - name: Set up SSH agent
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.EC2_SSH_KEY }}
-
-      # Deploy to EC2 (pull & run 최신 이미지)
-      - name: Deploy to EC2
+      # 3) Spring Boot 이미지 Build & Push (:latest + :sha7)
+      - name: Build and Push
+        env:
+          ACCOUNT: ${{ secrets.AWS_ACCOUNT_ID }}
+          REGION:  ${{ secrets.AWS_REGION }}
+          REPO:    ${{ secrets.ECR_REPO }}
         run: |
-          ssh -o StrictHostKeyChecking=no ubuntu@${{ secrets.EC2_HOST }} 'bash ~/deploy.sh'
+          IMAGE=$ACCOUNT.dkr.ecr.$REGION.amazonaws.com/$REPO
+          TAG=${GITHUB_SHA::7}
+          docker build -t $IMAGE:$TAG -t $IMAGE:latest .
+          docker push $IMAGE:$TAG
+          docker push $IMAGE:latest
+          echo "TAG=$TAG" >> $GITHUB_ENV
+
+      # 4) SSM으로 EC2에 배포 (compose가 ${IMAGE_TAG:-latest} 사용)
+      - name: Deploy on EC2 via SSM
+        run: |
+          CMD='aws ecr get-login-password --region ${{ secrets.AWS_REGION }} \
+                | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com \
+              && cd /srv/caddy \
+              && export IMAGE_TAG=${{ env.TAG }} \
+              && docker compose pull app \
+              && docker compose up -d app \
+              && docker image prune -f'
+          aws ssm send-command \
+            --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
+            --region ${{ secrets.AWS_REGION }} \
+            --document-name "AWS-RunShellScript" \
+            --comment "soomteum deploy ${{ env.TAG }}" \
+            --parameters commands=["$CMD"]
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,9 @@ name: deploy
 on:
   push:
     branches: [ dev ]
+  pull_request:
+    branches: [ dev ]   # ← 이 줄 추가
+    types: [ opened, reopened, synchronize, ready_for_review ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
       # 4) SSM Online 대기
       - name: Wait until SSM is Online
         run: |
-          for i in {1..30}; do
+          for i in {1..5}; do
             STATUS=$(aws ssm describe-instance-information \
               --query "InstanceInformationList[?InstanceId=='${{ secrets.EC2_INSTANCE_ID }}'].PingStatus" \
               --output text || true)
@@ -56,7 +56,7 @@ jobs:
               echo "SSM Online"
               exit 0
             fi
-            echo "SSM status: $STATUS (retry $i/30)"
+            echo "SSM status: $STATUS (retry $i/5)"
             sleep 10
           done
           echo "SSM not Online"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [ dev ]
   pull_request:
-    branches: [ dev ]   # ← 이 줄 추가
+    branches: [ dev ]
     types: [ opened, reopened, synchronize, ready_for_review ]
   workflow_dispatch:
 
@@ -45,7 +45,24 @@ jobs:
           docker push $IMAGE:latest
           echo "TAG=$TAG" >> $GITHUB_ENV
 
-      # 4) SSM으로 EC2에 배포 (compose가 ${IMAGE_TAG:-latest} 사용)
+      # 4) SSM Online 대기
+      - name: Wait until SSM is Online
+        run: |
+          for i in {1..30}; do
+            STATUS=$(aws ssm describe-instance-information \
+              --query "InstanceInformationList[?InstanceId=='${{ secrets.EC2_INSTANCE_ID }}'].PingStatus" \
+              --output text || true)
+            if [ "$STATUS" = "Online" ]; then
+              echo "SSM Online"
+              exit 0
+            fi
+            echo "SSM status: $STATUS (retry $i/30)"
+            sleep 10
+          done
+          echo "SSM not Online"
+          exit 1
+
+      # 5) SSM으로 EC2에 배포 (compose가 ${IMAGE_TAG:-latest} 사용)
       - name: Deploy on EC2 via SSM
         run: |
           CMD='aws ecr get-login-password --region ${{ secrets.AWS_REGION }} \
@@ -61,4 +78,3 @@ jobs:
             --document-name "AWS-RunShellScript" \
             --comment "soomteum deploy ${{ env.TAG }}" \
             --parameters commands=["$CMD"]
-


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- #31 

## 🛠 전체 아키텍처
```
사용자 ──(HTTPS)──> Caddy(EC2:80/443)
                      │
                      └─(Docker bridge)─> Spring Boot App(:8080)
```
- 데이터베이스: Amazon RDS for MySQL (동일 VPC)
- 이미지 레지스트리: Amazon ECR
- CI/CD: GitHub Actions (OIDC), SSM 원격 실행
- IAM: EC2 인스턴스 프로파일 + GitHub OIDC 배포 역할 + SSM 서비스 연결 역할
- DNS/TLS: Route53(A 레코드 → EC2 퍼블릭IP), Caddy가 Let’s Encrypt 자동 발급

