### PR TITLE
[Feat/#37] 마이페이지 사용자 정보 조회 및 닉네임 수정 기능 구현

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/user/controller/UserController.java
+++ b/src/main/java/com/comma/soomteum/domain/user/controller/UserController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "MyPage", description = "마이페이지")
 @RestController
-@RequestMapping(path = "/api/v1/users", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(path = "/api/my/profile", produces = MediaType.APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
 @Validated
 public class UserController {
@@ -23,13 +23,13 @@ public class UserController {
     private final UserService userService;
 
     @Operation(summary = "내 정보 조회", description = "로그인한 사용자의 정보를 조회합니다.")
-    @GetMapping("/me")
+    @GetMapping("/")
     public ApiResponse<UserProfileResponseDto> getUserProfile(@LoginUser Long userId) {
         return ApiResponse.ok(userService.getUserProfile(userId));
     }
 
     @Operation(summary = "닉네임 수정", description = "사용자의 닉네임을 수정합니다.")
-    @PatchMapping("/me/nickname")
+    @PatchMapping("/nickname")
     public ApiResponse<UserProfileResponseDto> updateNickname(@LoginUser Long userId, @Valid @RequestBody UserNicknameRequestDto userNicknameRequestDto) {
         return ApiResponse.ok(userService.updateNickname(userId, userNicknameRequestDto));
     }

--- a/src/main/java/com/comma/soomteum/domain/user/controller/UserController.java
+++ b/src/main/java/com/comma/soomteum/domain/user/controller/UserController.java
@@ -1,0 +1,36 @@
+package com.comma.soomteum.domain.user.controller;
+
+import com.comma.soomteum.domain.auth.annotation.LoginUser;
+import com.comma.soomteum.domain.user.dto.UserNicknameRequestDto;
+import com.comma.soomteum.domain.user.dto.UserProfileResponseDto;
+import com.comma.soomteum.domain.user.service.UserService;
+import com.comma.soomteum.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "MyPage", description = "마이페이지")
+@RestController
+@RequestMapping(path = "/api/v1/users", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+@Validated
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "내 정보 조회", description = "로그인한 사용자의 정보를 조회합니다.")
+    @GetMapping("/me")
+    public ApiResponse<UserProfileResponseDto> getUserProfile(@LoginUser Long userId) {
+        return ApiResponse.ok(userService.getUserProfile(userId));
+    }
+
+    @Operation(summary = "닉네임 수정", description = "사용자의 닉네임을 수정합니다.")
+    @PatchMapping("/me/nickname")
+    public ApiResponse<UserProfileResponseDto> updateNickname(@LoginUser Long userId, @Valid @RequestBody UserNicknameRequestDto userNicknameRequestDto) {
+        return ApiResponse.ok(userService.updateNickname(userId, userNicknameRequestDto));
+    }
+}

--- a/src/main/java/com/comma/soomteum/domain/user/dto/UserNicknameRequestDto.java
+++ b/src/main/java/com/comma/soomteum/domain/user/dto/UserNicknameRequestDto.java
@@ -1,0 +1,16 @@
+package com.comma.soomteum.domain.user.dto;
+
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserNicknameRequestDto {
+
+    @NotBlank(message = "닉네임은 비워둘 수 없습니다.")
+    private String nickname;
+}

--- a/src/main/java/com/comma/soomteum/domain/user/dto/UserProfileResponseDto.java
+++ b/src/main/java/com/comma/soomteum/domain/user/dto/UserProfileResponseDto.java
@@ -1,0 +1,24 @@
+package com.comma.soomteum.domain.user.dto;
+
+import com.comma.soomteum.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileResponseDto {
+
+    private String email;
+    private String nickname;
+
+    public static UserProfileResponseDto fromEntity(User user) {
+        return UserProfileResponseDto.builder()
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/comma/soomteum/domain/user/entity/User.java
+++ b/src/main/java/com/comma/soomteum/domain/user/entity/User.java
@@ -25,4 +25,8 @@ public class User extends BaseEntity {
     private String email;
 
     private Boolean isActive;
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/comma/soomteum/domain/user/service/UserService.java
+++ b/src/main/java/com/comma/soomteum/domain/user/service/UserService.java
@@ -1,0 +1,39 @@
+package com.comma.soomteum.domain.user.service;
+
+import com.comma.soomteum.domain.user.dto.UserNicknameRequestDto;
+import com.comma.soomteum.domain.user.dto.UserProfileResponseDto;
+import com.comma.soomteum.domain.user.entity.User;
+import com.comma.soomteum.domain.user.repository.UserRepository;
+import com.comma.soomteum.global.response.CustomException;
+import com.comma.soomteum.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 마이페이지 - 이메일, 닉네임 조회
+     **/
+    public UserProfileResponseDto getUserProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return UserProfileResponseDto.fromEntity(user);
+    }
+
+    /**
+     * 유저 닉네임 수정
+     **/
+    @Transactional
+    public UserProfileResponseDto updateNickname(Long userId, UserNicknameRequestDto userNicknameRequestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        user.updateNickname(userNicknameRequestDto.getNickname());
+        return UserProfileResponseDto.fromEntity(user);
+    }
+}


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #37

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 사용자 본인의 정보를 조회하고, 닉네임을 수정할 수 있는 API를 구현했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
   1. 사용자 정보 조회 API 추가                                                                                                 
       * GET /api/my/profile                                                                                                
       * 로그인한 사용자의 이메일과 닉네임을 반환합니다.                                                                        
       * @LoginUser 어노테이션을 통해 인증된 사용자의 userId를 받아 처리합니다.                                                 
                                                                                                                                
   2. 사용자 닉네임 수정 API 추가                                                                                               
       * PATCH /api/my/profile/nickname                                                                                        
       * Request Body로 받은 닉네임으로 사용자의 기존 닉네임을 수정합니다.                                                      
       * 수정된 최신 사용자 정보를 반환합니다.                                                                                  
                                                                                                                                
   3. `UserService` 비즈니스 로직 구현
       * getUserProfile(): 사용자 ID를 기반으로 사용자를 조회하고 UserProfileResponseDto를 반환합니다.
       * updateNickname(): 사용자 ID와 요청 DTO를 받아 닉네임을 변경합니다.
       * 사용자를 찾지 못할 경우 USER_NOT_FOUND 에러를 발생시킵니다.

   4. DTO 추가                                                                                                                  
       * UserProfileResponseDto: API 응답용 DTO                                                                                 
       * UserNicknameRequestDto: 닉네임 수정 요청용 DTO (@NotBlank 검증 추가)                                                   
                                                                                                                                
   5. `User` 엔티티 수정
       * updateNickname(): 닉네임 변경을 위한 메소드를 엔티티에 추가하여 데이터 일관성을 유지하도록 했습니다.


## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="1776" height="4640" alt="image" src="https://github.com/user-attachments/assets/5308caa1-7cec-47c0-af42-c63f569addf1" />
기본 닉네임은 임시유저000인데, 바뀐 걸 확인할 수 있습니다.