### PR TITLE
[Fix/#45] CORS 문제 해결

### DIFF
--- a/src/main/java/com/comma/soomteum/config/CorsGlobalConfig.java
+++ b/src/main/java/com/comma/soomteum/config/CorsGlobalConfig.java
@@ -1,0 +1,41 @@
+package com.comma.soomteum.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+@Configuration
+public class CorsGlobalConfig {
+
+    @Bean
+    public FilterRegistrationBean<CorsFilter> corsFilterRegistration() {
+        CorsConfiguration cfg = new CorsConfiguration();
+
+        // 정확 매칭 (운영/로컬)
+        cfg.setAllowedOriginPatterns(Arrays.asList(
+                "https://soomteum.site",
+                "http://localhost:3000"
+        ));
+
+        cfg.setAllowedMethods(Arrays.asList("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
+        // 브라우저가 보내는 다양한 헤더(security, UA 등)까지 포괄하려면 "*"가 안전
+        cfg.setAllowedHeaders(Collections.singletonList("*"));
+        cfg.setExposedHeaders(Arrays.asList("Authorization","Location"));
+        cfg.setAllowCredentials(true);
+        cfg.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource src = new UrlBasedCorsConfigurationSource();
+        src.registerCorsConfiguration("/**", cfg);
+
+        FilterRegistrationBean<CorsFilter> bean = new FilterRegistrationBean<>(new CorsFilter(src));
+        bean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return bean;
+    }
+}

--- a/src/main/java/com/comma/soomteum/config/SecurityConfig.java
+++ b/src/main/java/com/comma/soomteum/config/SecurityConfig.java
@@ -10,55 +10,30 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity(debug = false)
 @RequiredArgsConstructor
 public class SecurityConfig {
+
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
-                .formLogin(formLogin -> formLogin.disable())
-                .httpBasic(httpBasic -> httpBasic.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/api/auth/**","/error").permitAll()
-                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()  // 프리플라이트 허용
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/api/auth/**", "/error").permitAll()
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/kor/**").hasAuthority("ROLE_USER")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
-                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.sameOrigin()));
-
+                .headers(headers -> headers.frameOptions(f -> f.sameOrigin()));
 
         return http.build();
     }
-
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-
-        configuration.setAllowedOrigins(Arrays.asList(
-                "http://localhost:8080"
-        ));
-
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(Arrays.asList("*"));
-        configuration.setAllowCredentials(true);
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-
-        return source;
-    }
 }
-

--- a/src/main/java/com/comma/soomteum/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/comma/soomteum/domain/auth/JwtAuthenticationFilter.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.http.HttpMethod;
 
 import java.io.IOException;
 
@@ -44,6 +45,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws IOException, ServletException {
+
+        // CORS preflight는 인증 검사 없이 바로 통과
+        if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+            if (log.isDebugEnabled()) {
+                log.debug("[JWT] Preflight bypass. uri={}, thread={}", request.getRequestURI(), Thread.currentThread().getName());
+            }
+            filterChain.doFilter(request, response);
+            return;
+        }
 
         // 이미 다른 필터/디스패치에서 인증된 경우 중복 작업을 피함
         var context = SecurityContextHolder.getContext();


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #45 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 문제: 프론트 (http://localhost:3000)에서 API 호출 시 Invalid CORS request(403) 발생
- 원인: Spring Security/WebMvc/Caddy 등 여러 레이어에서 CORS가 중복/충돌하며 프리플라이트(OPTIONS) 차단
- 해결: 전역 CorsFilter 1곳으로 단일화하고, 허용 오리진/헤더/메서드를 명시

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 추가: src/main/java/com/comma/soomteum/config/CorsGlobalConfig.java
  - FilterRegistrationBean<CorsFilter> 등록, Ordered.HIGHEST_PRECEDENCE로 최우선 실행
  - allowedOriginPatterns: https://soomteum.site, http://localhost:3000 (필요 시 http://localhost:* 확장 가능)
  - allowedMethods: GET, POST, PUT, PATCH, DELETE, OPTIONS
  - allowedHeaders: * (Authorization 등 전체 허용), exposedHeaders: Authorization, Location
  - allowCredentials(true), maxAge(3600)
- 수정: SecurityConfig
  - cors(cors -> ...), CorsConfigurationSource 삭제 (CORS 단일화)
  - OPTIONS /** permitAll 유지, 나머지 인증/인가 정책은 그대로
  - JwtAuthenticationFilter는 계속 UsernamePasswordAuthenticationFilter 이전에 배치
- 수정: JwtAuthenticationFilter
  - OPTIONS 요청 즉시 패스 로직 유지(안전장치)
- 정리: 프로젝트 내 WebConfig.addCorsMappings(...) / 컨트롤러 @CrossOrigin 존재 시 제거
