### PR TITLE
[Feat/#42] 나의 여행지 저장 API 구현

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceLikeController.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceLikeController.java
@@ -3,6 +3,7 @@ package com.comma.soomteum.domain.userPlace.controller;
 import com.comma.soomteum.domain.auth.annotation.LoginUser;
 import com.comma.soomteum.domain.user.entity.User;
 import com.comma.soomteum.domain.userPlace.dto.UserPlaceResponseDto;
+import com.comma.soomteum.domain.userPlace.enums.UserActionType;
 import com.comma.soomteum.domain.userPlace.service.UserPlaceService;
 import com.comma.soomteum.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -57,7 +58,7 @@ public class PlaceLikeController {
     @GetMapping("/{placeId}/likes/count")
     public ResponseEntity<ApiResponse<Long>> getPlaceLikeCount(
             @PathVariable Long placeId) {
-        long likeCount = userPlaceService.getPlaceLikeCount(placeId);
+        long likeCount = userPlaceService.getActionCount(placeId, UserActionType.LIKE);
         return ResponseEntity.ok(ApiResponse.ok(likeCount));
     }
 }

--- a/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceLikeController.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceLikeController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/places")
-public class UserPlaceController {
+public class PlaceLikeController {
 
     private final UserPlaceService userPlaceService;
 

--- a/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceSaveController.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceSaveController.java
@@ -1,0 +1,4 @@
+package com.comma.soomteum.domain.userPlace.controller;
+
+public class PlaceSaveController {
+}

--- a/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceSaveController.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceSaveController.java
@@ -1,4 +1,86 @@
 package com.comma.soomteum.domain.userPlace.controller;
 
+import com.comma.soomteum.domain.auth.annotation.LoginUser;
+import com.comma.soomteum.domain.user.entity.User;
+import com.comma.soomteum.domain.userPlace.dto.UserPlacePageResponseDto;
+import com.comma.soomteum.domain.userPlace.dto.UserPlaceResponseDto;
+import com.comma.soomteum.domain.userPlace.enums.UserActionType;
+import com.comma.soomteum.domain.userPlace.service.UserPlaceService;
+import com.comma.soomteum.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "My Saved Places", description = "내 여행지 저장(북마크) API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/me/places")
 public class PlaceSaveController {
+
+    private final UserPlaceService userPlaceService;
+
+    @Operation(
+            summary = "저장 설정(멱등)",
+            description = "해당 장소를 내 저장 목록에 추가합니다. 이미 저장되어 있어도 성공을 반환합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "저장 성공",
+                    content = @Content(schema = @Schema(implementation = UserPlaceResponseDto.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "장소를 찾을 수 없음")
+    })
+    @PutMapping("/{placeId}/save")
+    public ResponseEntity<ApiResponse<UserPlaceResponseDto>> save(
+            @Parameter(hidden = true) @LoginUser User user,
+            @Parameter(description = "장소 ID") @PathVariable Long placeId) {
+
+        var dto = userPlaceService.setAction(user.getUserId(), placeId, UserActionType.SAVE, true);
+        return ResponseEntity.ok(ApiResponse.ok(dto));
+    }
+
+    @Operation(
+            summary = "저장 해제(멱등)",
+            description = "해당 장소를 내 저장 목록에서 제거합니다. 이미 제거된 상태여도 성공을 반환합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "저장 해제 성공",
+                    content = @Content(schema = @Schema(implementation = UserPlaceResponseDto.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "장소를 찾을 수 없음")
+    })
+    @DeleteMapping("/{placeId}/save")
+    public ResponseEntity<ApiResponse<UserPlaceResponseDto>> unsave(
+            @Parameter(hidden = true) @LoginUser User user,
+            @Parameter(description = "장소 ID") @PathVariable Long placeId) {
+
+        var dto = userPlaceService.setAction(user.getUserId(), placeId, UserActionType.SAVE, false);
+        return ResponseEntity.ok(ApiResponse.ok(dto));
+    }
+
+    @Operation(
+            summary = "내 저장 목록 조회",
+            description = "현재 로그인 사용자의 저장 목록을 페이징으로 조회합니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = UserPlacePageResponseDto.class)))
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<UserPlacePageResponseDto>> mySaved(
+            @Parameter(hidden = true) @LoginUser User user,
+            @Parameter(description = "페이지/사이즈 등 페이징 파라미터") @PageableDefault(size = 20) Pageable pageable) {
+
+        var page = userPlaceService.getMyPlaces(user.getUserId(), UserActionType.SAVE, pageable);
+        return ResponseEntity.ok(ApiResponse.ok(page));
+    }
 }

--- a/src/main/java/com/comma/soomteum/domain/userPlace/dto/UserPlaceItemDto.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/dto/UserPlaceItemDto.java
@@ -1,0 +1,33 @@
+package com.comma.soomteum.domain.userPlace.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * “내 저장 목록” 한 줄 아이템 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(name = "UserPlaceItem", description = "내가 저장한 장소 아이템")
+public class UserPlaceItemDto {
+
+    @Schema(description = "장소 ID", example = "123")
+    private Long placeId;
+
+    @Schema(description = "장소 이름/타이틀", example = "경복궁")
+    private String title;
+
+    @Schema(description = "대표 이미지 URL", example = "https://.../image.jpg")
+    private String imageUrl;
+
+    @Schema(description = "주소 또는 지역명", example = "서울 종로구 사직로 161")
+    private String address;
+
+    @Schema(description = "저장한 시각", example = "2025-08-19T11:54:00")
+    private LocalDateTime savedAt;
+
+}

--- a/src/main/java/com/comma/soomteum/domain/userPlace/dto/UserPlacePageResponseDto.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/dto/UserPlacePageResponseDto.java
@@ -1,0 +1,63 @@
+package com.comma.soomteum.domain.userPlace.dto;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * 저장 목록 페이지 응답 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(name = "UserPlacePageResponse", description = "내 저장 목록(페이지)")
+public class UserPlacePageResponseDto {
+
+    @ArraySchema(schema = @Schema(implementation = UserPlaceItemDto.class))
+    private List<UserPlaceItemDto> content;
+
+    @Schema(description = "현재 페이지(0-base)", example = "0")
+    private int page;
+
+    @Schema(description = "페이지 크기", example = "20")
+    private int size;
+
+    @Schema(description = "전체 요소 수", example = "134")
+    private long totalElements;
+
+    @Schema(description = "전체 페이지 수", example = "7")
+    private int totalPages;
+
+    @Schema(description = "첫 페이지 여부", example = "true")
+    private boolean first;
+
+    @Schema(description = "마지막 페이지 여부", example = "false")
+    private boolean last;
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    private boolean hasNext;
+
+    @Schema(description = "이전 페이지 존재 여부", example = "false")
+    private boolean hasPrevious;
+
+    public static UserPlacePageResponseDto of(List<UserPlaceItemDto> content,
+                                              int page, int size,
+                                              long totalElements, int totalPages,
+                                              boolean first, boolean last,
+                                              boolean hasNext, boolean hasPrevious) {
+        return UserPlacePageResponseDto.builder()
+                .content(content)
+                .page(page)
+                .size(size)
+                .totalElements(totalElements)
+                .totalPages(totalPages)
+                .first(first)
+                .last(last)
+                .hasNext(hasNext)
+                .hasPrevious(hasPrevious)
+                .build();
+    }
+}

--- a/src/main/java/com/comma/soomteum/domain/userPlace/dto/UserPlaceResponseDto.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/dto/UserPlaceResponseDto.java
@@ -1,14 +1,64 @@
 package com.comma.soomteum.domain.userPlace.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.comma.soomteum.domain.userPlace.enums.UserActionType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
 
+import java.time.LocalDateTime;
+
+/**
+ * 좋아요/저장 토글 공통 응답 DTO
+ */
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(name = "UserPlaceResponse", description = "장소 좋아요/저장 요청에 대한 응답")
 public class UserPlaceResponseDto {
+
+    @Schema(description = "장소 ID", example = "123")
+    private Long placeId;
+
+    @Schema(description = "액션 타입", example = "LIKE")
+    private UserActionType type;
+
+    @Schema(description = "현재 유저 관점 상태 (true=켜짐: 좋아요/저장됨)", example = "true")
+    private boolean enabled;
+
+    @Schema(description = "이번 호출로 실제로 상태가 바뀌었는지", example = "true")
+    private boolean changed;
+
+    @Schema(description = "좋아요 수(Like일 때만 제공)", example = "42", nullable = true)
+    private Long likeCount;
+
+    @Schema(description = "메시지(선택)", example = "LIKE ON")
     private String message;
+
+    @Schema(description = "생성 시각(선택)", example = "2025-08-19T11:54:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 시각(선택)", example = "2025-08-19T11:55:10")
+    private LocalDateTime updatedAt;
+
+    public static UserPlaceResponseDto of(Long placeId,
+                                          UserActionType type,
+                                          boolean enabled,
+                                          boolean changed,
+                                          Long likeCount,
+                                          String message,
+                                          LocalDateTime createdAt,
+                                          LocalDateTime updatedAt) {
+        return UserPlaceResponseDto.builder()
+                .placeId(placeId)
+                .type(type)
+                .enabled(enabled)
+                .changed(changed)
+                .likeCount(likeCount)
+                .message(message)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
+    }
 }

--- a/src/main/java/com/comma/soomteum/domain/userPlace/entity/UserPlace.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/entity/UserPlace.java
@@ -17,9 +17,13 @@ import lombok.NoArgsConstructor;
         name = "user_place",
         uniqueConstraints = {
                 @UniqueConstraint(
-                        name = "user_place_unique",
-                        columnNames = {"user_id", "place_id"}
+                        name = "uq_user_place_user_place_type",
+                        columnNames = {"user_id", "place_id", "type"}
                 )
+        },
+        indexes = {
+                @Index(name = "idx_user_place_place_type", columnList = "place_id,type"), // like 카운트/랭킹에 유용
+                @Index(name = "idx_user_place_user_type",  columnList = "user_id,type")   // 내 저장/좋아요 목록 조회
         }
 )
 public class UserPlace extends BaseEntity {
@@ -37,8 +41,8 @@ public class UserPlace extends BaseEntity {
     @JoinColumn(name = "place_id", nullable = false)
     private Place place;
 
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
     private UserActionType type;
 
     @Builder

--- a/src/main/java/com/comma/soomteum/domain/userPlace/repository/UserPlaceRepository.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/repository/UserPlaceRepository.java
@@ -1,10 +1,23 @@
 package com.comma.soomteum.domain.userPlace.repository;
 
 import com.comma.soomteum.domain.userPlace.entity.UserPlace;
+import com.comma.soomteum.domain.userPlace.enums.UserActionType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface UserPlaceRepository extends JpaRepository<UserPlace, Long> {
+
+    @Deprecated
     Optional<UserPlace> findByUser_UserIdAndPlace_PlaceId(Long userId, Long placeId);
+
+    Optional<UserPlace> findByUser_UserIdAndPlace_PlaceIdAndType(Long userId, Long placeId, UserActionType type);
+
+    boolean existsByUser_UserIdAndPlace_PlaceIdAndType(Long userId, Long placeId, UserActionType type);
+
+    long countByPlace_PlaceIdAndType(Long placeId, UserActionType type);
+
+    Page<UserPlace> findByUser_UserIdAndType(Long userId, UserActionType type, Pageable pageable);
 }

--- a/src/main/java/com/comma/soomteum/domain/userPlace/repository/UserPlaceRepository.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/repository/UserPlaceRepository.java
@@ -4,6 +4,7 @@ import com.comma.soomteum.domain.userPlace.entity.UserPlace;
 import com.comma.soomteum.domain.userPlace.enums.UserActionType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -19,5 +20,6 @@ public interface UserPlaceRepository extends JpaRepository<UserPlace, Long> {
 
     long countByPlace_PlaceIdAndType(Long placeId, UserActionType type);
 
+    @EntityGraph(attributePaths = "place")
     Page<UserPlace> findByUser_UserIdAndType(Long userId, UserActionType type, Pageable pageable);
 }

--- a/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
@@ -2,6 +2,8 @@ package com.comma.soomteum.domain.userPlace.service;
 
 import com.comma.soomteum.domain.place.service.PlaceService;
 import com.comma.soomteum.domain.user.repository.UserRepository;
+import com.comma.soomteum.domain.userPlace.dto.UserPlaceItemDto;
+import com.comma.soomteum.domain.userPlace.dto.UserPlacePageResponseDto;
 import com.comma.soomteum.domain.userPlace.dto.UserPlaceResponseDto;
 import com.comma.soomteum.domain.userPlace.entity.UserPlace;
 import com.comma.soomteum.domain.userPlace.enums.UserActionType;
@@ -11,6 +13,8 @@ import com.comma.soomteum.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import org.springframework.data.domain.Pageable;
 
 @Service
 @RequiredArgsConstructor
@@ -68,6 +72,34 @@ public class UserPlaceService {
         }
         return userPlaceRepository.countByPlace_PlaceIdAndType(placeId, type);
     }
+
+    @Transactional(readOnly = true)
+    public UserPlacePageResponseDto getMyPlaces(Long userId, UserActionType type, Pageable pageable) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        var page = userPlaceRepository.findByUser_UserIdAndType(userId, type, pageable);
+
+        var items = page.getContent().stream().map(up -> {
+            var p = up.getPlace();
+            return UserPlaceItemDto.builder()
+                    .placeId(p.getPlaceId())
+                    // .title(p.getName())
+                    // .imageUrl(p.getThumbnailUrl())
+                    // .address(p.getAddress())
+                    .savedAt(up.getCreatedAt())
+                    .build();
+        }).toList();
+
+        return UserPlacePageResponseDto.of(
+                items,
+                page.getNumber(), page.getSize(),
+                page.getTotalElements(), page.getTotalPages(),
+                page.isFirst(), page.isLast(),
+                page.hasNext(), page.hasPrevious()
+        );
+    }
+
 
     @Transactional public UserPlaceResponseDto likePlace(Long userId, Long placeId) {
         return setAction(userId, placeId, UserActionType.LIKE, true);

--- a/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
@@ -1,8 +1,6 @@
 package com.comma.soomteum.domain.userPlace.service;
 
-import com.comma.soomteum.domain.place.entity.Place;
 import com.comma.soomteum.domain.place.service.PlaceService;
-import com.comma.soomteum.domain.user.entity.User;
 import com.comma.soomteum.domain.user.repository.UserRepository;
 import com.comma.soomteum.domain.userPlace.dto.UserPlaceResponseDto;
 import com.comma.soomteum.domain.userPlace.entity.UserPlace;
@@ -24,12 +22,11 @@ public class UserPlaceService {
 
     @Transactional
     public UserPlaceResponseDto setAction(Long userId, Long placeId, UserActionType type, boolean enable) {
-        User user = userRepository.findById(userId)
+        var user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        Place place = placeService.findPlaceById(placeId);
+        var place = placeService.findPlaceById(placeId);
 
-        var existing = userPlaceRepository
-                .findByUser_UserIdAndPlace_PlaceIdAndType(userId, placeId, type);
+        var existing = userPlaceRepository.findByUser_UserIdAndPlace_PlaceIdAndType(userId, placeId, type);
 
         boolean changed = false;
 
@@ -54,34 +51,34 @@ public class UserPlaceService {
             }
         }
 
-        Long likeCount = (type == UserActionType.LIKE) ? place.getLikeCount() : null;
-
         return UserPlaceResponseDto.builder()
                 .placeId(placeId)
                 .type(type)
-                .enabled(enable)
-                .changed(changed)
-                .likeCount(likeCount)
+                .enabled(enable)   // 현재 상태
+                .changed(changed)  // 실제 변경 여부
                 .message(type + " " + (enable ? "ON" : "OFF"))
                 .build();
     }
 
+    // 좋아요용 카운트
     @Transactional(readOnly = true)
     public long getActionCount(Long placeId, UserActionType type) {
         if (type == UserActionType.LIKE) {
-            Place place = placeService.findPlaceById(placeId);
-            return place.getLikeCount();
+            return placeService.findPlaceById(placeId).getLikeCount();
         }
         return userPlaceRepository.countByPlace_PlaceIdAndType(placeId, type);
     }
 
-    @Transactional
-    public UserPlaceResponseDto likePlace(Long userId, Long placeId) {
+    @Transactional public UserPlaceResponseDto likePlace(Long userId, Long placeId) {
         return setAction(userId, placeId, UserActionType.LIKE, true);
     }
-
-    @Transactional
-    public UserPlaceResponseDto unlikePlace(Long userId, Long placeId) {
+    @Transactional public UserPlaceResponseDto unlikePlace(Long userId, Long placeId) {
         return setAction(userId, placeId, UserActionType.LIKE, false);
+    }
+    @Transactional public UserPlaceResponseDto savePlace(Long userId, Long placeId) {
+        return setAction(userId, placeId, UserActionType.SAVE, true);
+    }
+    @Transactional public UserPlaceResponseDto unsavePlace(Long userId, Long placeId) {
+        return setAction(userId, placeId, UserActionType.SAVE, false);
     }
 }

--- a/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
@@ -23,49 +23,65 @@ public class UserPlaceService {
     private final PlaceService placeService;
 
     @Transactional
-    public UserPlaceResponseDto likePlace(Long userId, Long placeId) {
+    public UserPlaceResponseDto setAction(Long userId, Long placeId, UserActionType type, boolean enable) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         Place place = placeService.findPlaceById(placeId);
 
-        userPlaceRepository.findByUser_UserIdAndPlace_PlaceId(userId, placeId).ifPresent(userPlace -> {
-            throw new CustomException(ErrorCode.ALREADY_LIKED_PLACE);
-        });
+        var existing = userPlaceRepository
+                .findByUser_UserIdAndPlace_PlaceIdAndType(userId, placeId, type);
 
-        UserPlace userPlace = UserPlace.builder()
-                .user(user)
-                .place(place)
-                .type(UserActionType.LIKE)
-                .build();
+        boolean changed = false;
 
-        userPlaceRepository.save(userPlace);
-        place.increaseLikeCount();
+        if (enable) {
+            if (existing.isEmpty()) {
+                try {
+                    userPlaceRepository.save(UserPlace.builder()
+                            .user(user)
+                            .place(place)
+                            .type(type)
+                            .build());
+                    if (type == UserActionType.LIKE) place.increaseLikeCount();
+                    changed = true;
+                } catch (org.springframework.dao.DataIntegrityViolationException ignore) {
+                }
+            }
+        } else {
+            if (existing.isPresent()) {
+                userPlaceRepository.delete(existing.get());
+                if (type == UserActionType.LIKE) place.decreaseLikeCount();
+                changed = true;
+            }
+        }
 
-        return UserPlaceResponseDto.builder()
-                .message("userId: " + userId + " PlaceId: " + placeId + " 좋아요가 성공했습니다.")
-                .build();
-    }
-
-    @Transactional
-    public UserPlaceResponseDto unlikePlace(Long userId, Long placeId) {
-        userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        Place place = placeService.findPlaceById(placeId);
-
-        UserPlace userPlace = userPlaceRepository.findByUser_UserIdAndPlace_PlaceId(userId, placeId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_LIKED_PLACE));
-
-        userPlaceRepository.delete(userPlace);
-        place.decreaseLikeCount();
+        Long likeCount = (type == UserActionType.LIKE) ? place.getLikeCount() : null;
 
         return UserPlaceResponseDto.builder()
-                .message("userId: " + userId + " PlaceId: " + placeId + " 좋아요 해제가 성공했습니다.")
+                .placeId(placeId)
+                .type(type)
+                .enabled(enable)
+                .changed(changed)
+                .likeCount(likeCount)
+                .message(type + " " + (enable ? "ON" : "OFF"))
                 .build();
     }
 
     @Transactional(readOnly = true)
-    public long getPlaceLikeCount(Long placeId) {
-        Place place = placeService.findPlaceById(placeId);
-        return place.getLikeCount();
+    public long getActionCount(Long placeId, UserActionType type) {
+        if (type == UserActionType.LIKE) {
+            Place place = placeService.findPlaceById(placeId);
+            return place.getLikeCount();
+        }
+        return userPlaceRepository.countByPlace_PlaceIdAndType(placeId, type);
+    }
+
+    @Transactional
+    public UserPlaceResponseDto likePlace(Long userId, Long placeId) {
+        return setAction(userId, placeId, UserActionType.LIKE, true);
+    }
+
+    @Transactional
+    public UserPlaceResponseDto unlikePlace(Long userId, Long placeId) {
+        return setAction(userId, placeId, UserActionType.LIKE, false);
     }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #42 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 여행지 저장 API 구현 (저장, 삭제, 조회)
- 컨트롤러 분리: 공개 집계(좋아요) vs 내 컬렉션(저장) 역할 분리
- 서비스 통합: type(LIKE|SAVE) 기반의 멱등 토글 단일 서비스로 중복 제거
- 레포 수정: 조회 조건에 type 포함(버그 원인 제거) + 페이지 조회/카운트 메서드 추가
- 스키마 수정: 유니크 제약을 (user_id, place_id, type)로 변경, 조회 인덱스 추가
- DTO 추가: 토글 응답, 내 저장 목록 아이템/페이지 DTO
- Swagger 문서화: 태그 분리(Place Likes / My Saved Places), 보안 스키마 적용
- 호환 래퍼: 기존 getPlaceLikeCount 호출부를 위한 임시 래퍼 제공

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 저장(내 컬렉션)
  - PUT /api/me/places/{placeId}/save : 저장(멱등)
  - DELETE /api/me/places/{placeId}/save : 저장 해제(멱등)
  - GET /api/me/places : 내 저장 목록(페이징)

- 컨트롤러 분리
  - PlaceLikeController : 좋아요 토글/카운트 (공개 지표)
  - PlaceSaveController : 저장 토글/내 목록 (개인 지표)
  - Swagger 태그 분리로 문서 가독성↑

- 서비스 구조
  - 단일 메서드로 통합: setAction(userId, placeId, type, enable)
    - 호출 결과를 실제 상태 기준으로 응답(enabled, changed, likeCount)
    - 중복 인서트 경합은 유니크 제약 위반을 멱등 성공으로 처리
    - 좋아요일 때만 Place.likeCount 증감(비정규화 카운트 신뢰)
  - 목록 조회: getMyPlaces(userId, SAVE, pageable) (N+1 방지로 연관 로딩)

- 엔티티/DB 스키마
  - 유니크 제약: (user_id, place_id, type)로 수정
  - 인덱스: (place_id, type) / (user_id, type) 추가
  - Enum은 문자열 저장을 유지(가독성/회귀 안전)

## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="1082" height="169" alt="image" src="https://github.com/user-attachments/assets/6133d5ee-d8d8-40bd-a9ec-fe0b974c3432" />
