### PR TITLE
[Refactor/#55] userPlace like, save 로직 개편

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/place/service/PlaceService.java
+++ b/src/main/java/com/comma/soomteum/domain/place/service/PlaceService.java
@@ -88,16 +88,16 @@ public class PlaceService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public Place findOrCreatePlace(String contentId, Long regionId, Long themeId, BigDecimal cnctrLevel) {
+    public Place findOrCreatePlace(String contentId, String regionName, String themeName, BigDecimal cnctrLevel) {
         return placeRepository.findByContentId(contentId)
-                .orElseGet(() -> createPlace(contentId, regionId, themeId, cnctrLevel));
+                .orElseGet(() -> createPlace(contentId, regionName, themeName, cnctrLevel));
     }
 
-    private Place createPlace(String contentId, Long regionId, Long themeId, BigDecimal cnctrLevel) {
-        var region = regionRepository.findById(regionId)
+    private Place createPlace(String contentId, String regionName, String themeName, BigDecimal cnctrLevel) {
+        var region = regionRepository.findByName(regionName)
                 .orElseThrow(() -> new CustomException(ErrorCode.REGION_NOT_FOUND));
         
-        var theme = themeRepository.findById(themeId)
+        var theme = themeRepository.findByName(themeName)
                 .orElseThrow(() -> new CustomException(ErrorCode.THEME_NOT_FOUND));
 
         var place = Place.builder()

--- a/src/main/java/com/comma/soomteum/domain/theme/repository/ThemeRepository.java
+++ b/src/main/java/com/comma/soomteum/domain/theme/repository/ThemeRepository.java
@@ -4,6 +4,9 @@ import com.comma.soomteum.domain.theme.entity.Theme;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ThemeRepository extends JpaRepository<Theme, Long> {
+    Optional<Theme> findByName(String name);
 }

--- a/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceLikeController.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceLikeController.java
@@ -42,8 +42,8 @@ public class PlaceLikeController {
         UserPlaceResponseDto responseDto = userPlaceService.setActionByContentId(
                 user.getUserId(),
                 request.getContentId(), 
-                request.getRegionId(), 
-                request.getThemeId(), 
+                request.getRegionName(), 
+                request.getThemeName(), 
                 request.getCnctrLevel(),
                 UserActionType.LIKE, 
                 true);

--- a/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceSaveController.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceSaveController.java
@@ -47,8 +47,8 @@ public class PlaceSaveController {
         var dto = userPlaceService.setActionByContentId(
                 user.getUserId(),
                 request.getContentId(), 
-                request.getRegionId(), 
-                request.getThemeId(), 
+                request.getRegionName(), 
+                request.getThemeName(), 
                 request.getCnctrLevel(),
                 UserActionType.SAVE, 
                 true);
@@ -91,7 +91,7 @@ public class PlaceSaveController {
             @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(value = "page", defaultValue = "0") int page,
             @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "20") int size) {
 
-        var result = userPlaceService.getMyPlaces(user.getUserId(), UserActionType.SAVE, page, size);
+        var result = userPlaceService.getMyPlaces(user.getUserId (), UserActionType.SAVE, page, size);
         return ResponseEntity.ok(ApiResponse.ok(result));
     }
 }

--- a/src/main/java/com/comma/soomteum/domain/userPlace/dto/PlaceActionRequestDto.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/dto/PlaceActionRequestDto.java
@@ -19,13 +19,13 @@ public class PlaceActionRequestDto {
     @Schema(description = "공공데이터 API의 컨텐츠 ID", example = "123456")
     private String contentId;
 
-    @NotNull
-    @Schema(description = "지역 ID", example = "1")
-    private Long regionId;
+    @NotBlank
+    @Schema(description = "지역명", example = "서울")
+    private String regionName;
 
-    @NotNull
-    @Schema(description = "테마 ID", example = "2")
-    private Long themeId;
+    @NotBlank
+    @Schema(description = "테마명", example = "자연")
+    private String themeName;
 
     @NotNull
     @Schema(description = "혼잡도 레벨", example = "3.5")

--- a/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
@@ -203,7 +203,7 @@ public class UserPlaceService {
     }
 
     @Transactional
-    public UserPlaceResponseDto setActionByContentId(Long userId, String contentId, Long regionId, Long themeId, BigDecimal cnctrLevel, UserActionType type, boolean enable) {
+    public UserPlaceResponseDto setActionByContentId(Long userId, String contentId, String regionName, String themeName, BigDecimal cnctrLevel, UserActionType type, boolean enable) {
         if (userId == null) {
             throw new CustomException(ErrorCode.USER_NOT_FOUND);
         }
@@ -211,7 +211,7 @@ public class UserPlaceService {
         var user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         
-        var place = placeService.findOrCreatePlace(contentId, regionId, themeId, cnctrLevel);
+        var place = placeService.findOrCreatePlace(contentId, regionName, themeName, cnctrLevel);
         
         if (place.getPlaceId() == null) {
             throw new CustomException(ErrorCode.PLACE_NOT_FOUND);


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #55

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- Place like/save controller의 파라미터를 ID 기반에서 name 기반으로 변경하여API 사용성을 개선했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
  - PlaceActionRequestDto: regionId(Long) → regionName(String), themeId(Long)
  → themeName(String)로 변경
  - PlaceLikeController: 좋아요 API에서 새로운 name 기반 파라미터 사용
  - PlaceSaveController: 저장 API에서 새로운 name 기반 파라미터 사용
  - UserPlaceService: setActionByContentId 메서드 시그니처를 name 기반으로
  수정
  - PlaceService: findOrCreatePlace, createPlace 메서드를 name 기반 조회로
  변경
  - ThemeRepository: findByName 메서드 추가 (RegionRepository는 기존에 존재)
  - 모든 관련 로직을 ID 조회에서 name 조회로 일관성 있게 변경

## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="1421" height="1342" alt="image" src="https://github.com/user-attachments/assets/0da52f0c-66a6-4f72-ab65-1ecbe9242ce4" />
