### PR TITLE
[Feat/#60] 여행지 상세 통합 조회 API 구현

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/ai/dto/AiReviewRequest.java
+++ b/src/main/java/com/comma/soomteum/domain/ai/dto/AiReviewRequest.java
@@ -1,9 +1,11 @@
 package com.comma.soomteum.domain.ai.dto;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class AiReviewRequest {
     private String placeName;
 }

--- a/src/main/java/com/comma/soomteum/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/comma/soomteum/domain/place/controller/PlaceController.java
@@ -1,16 +1,69 @@
 package com.comma.soomteum.domain.place.controller;
 
-import com.comma.soomteum.domain.ai.adapter.AiServiceAdapter;
+import com.comma.soomteum.domain.place.dto.response.PlaceDetailIntegratedResponseDto;
+import com.comma.soomteum.domain.place.service.PlaceDetailIntegratedService;
+import com.comma.soomteum.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
 
 @Tag(name = "여행지", description = "여행지와 관련된 로직")
 @RestController
-@RequestMapping("/api/places")
+@RequestMapping(path = "/api/places", produces = MediaType.APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
 public class PlaceController {
 
+    private final PlaceDetailIntegratedService placeDetailIntegratedService;
 
+    @Operation(
+            summary = "여행지 상세 통합 정보 조회",
+            description = """
+                    여행지 상세 조회 시 필요한 모든 정보를 통합하여 제공합니다.
+                    
+                    **제공 정보:**
+                    - 여행지 이름, 사진, 주소, 지역, 테마, 소개
+                    - 한적함 등급 (1-5단계, -1: 데이터 없음)
+                    - 좋아요 수
+                    - AI 꿀팁 요약 (강릉시만 제공)
+                    - 근처 공영주차장 정보 (강릉시만 제공)
+                    
+                    **강릉시 전용 기능:**
+                    - AI가 생성한 여행 꿀팁 요약
+                    - 주변 5km 이내 공영주차장 최대 5개 정보
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200", 
+                    description = "통합 정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = PlaceDetailIntegratedResponseDto.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404", 
+                    description = "여행지를 찾을 수 없음"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500", 
+                    description = "서버 내부 오류"
+            )
+    })
+    @GetMapping("/integrated/{contentId}")
+    public Mono<ApiResponse<PlaceDetailIntegratedResponseDto>> getIntegratedPlaceDetail(
+            @Parameter(description = "공공데이터 API의 컨텐츠 ID", required = true, example = "128758")
+            @PathVariable String contentId) {
+        
+        return placeDetailIntegratedService.getIntegratedPlaceDetail(contentId)
+                .map(ApiResponse::ok)
+                .onErrorReturn(new ApiResponse<>(null, false, null, null));
+    }
 }

--- a/src/main/java/com/comma/soomteum/domain/place/dto/response/PlaceDetailIntegratedResponseDto.java
+++ b/src/main/java/com/comma/soomteum/domain/place/dto/response/PlaceDetailIntegratedResponseDto.java
@@ -1,0 +1,53 @@
+package com.comma.soomteum.domain.place.dto.response;
+
+import com.comma.soomteum.domain.parking.dto.PublicParkingResponseDto;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "여행지 상세 통합 정보 응답")
+public class PlaceDetailIntegratedResponseDto {
+
+    @Schema(description = "여행지 이름", example = "경포해수욕장")
+    private String placeName;
+
+    @Schema(description = "여행지 대표 사진 URL", example = "http://tong.visitkorea.or.kr/cms/resource/58/2938658_image2_1.bmp")
+    private String placeImageUrl;
+
+    @Schema(description = "여행지 주소", example = "강원특별자치도 강릉시 창해로 514 (안현동)")
+    private String placeAddress;
+
+    @Schema(description = "여행지 지역", example = "강릉시")
+    private String region;
+
+    @Schema(description = "테마 분류", example = "자연관광지")
+    private String theme;
+
+    @Schema(description = "한적함 등급 (1-5단계, -1: 데이터 없음)", example = "3")
+    private Integer tranquilityLevel;
+
+    @Schema(description = "좋아요 수", example = "127")
+    private Long likeCount;
+
+    @Schema(description = "여행지 소개", example = "동해안 최대 해변으로 유명하며...")
+    private String introduction;
+
+    @Schema(description = "AI 꿀팁 요약 (강릉시만 제공)")
+    private String aiTipSummary;
+
+    @Schema(description = "근처 공영주차장 목록 (강릉시만 제공)")
+    private List<PublicParkingResponseDto> nearbyParkingLots;
+
+    @Schema(description = "경도", example = "128.8761")
+    private String longitude;
+
+    @Schema(description = "위도", example = "37.7519")
+    private String latitude;
+}

--- a/src/main/java/com/comma/soomteum/domain/place/service/PlaceDetailIntegratedService.java
+++ b/src/main/java/com/comma/soomteum/domain/place/service/PlaceDetailIntegratedService.java
@@ -1,0 +1,196 @@
+package com.comma.soomteum.domain.place.service;
+
+import com.comma.soomteum.domain.ai.dto.AiReviewRequest;
+import com.comma.soomteum.domain.ai.dto.AiReviewResponse;
+import com.comma.soomteum.domain.ai.service.AiReviewService;
+import com.comma.soomteum.domain.parking.dto.PublicParkingResponseDto;
+import com.comma.soomteum.domain.parking.service.PublicParkingService;
+import com.comma.soomteum.domain.place.dto.TourApiRequestDto;
+import com.comma.soomteum.domain.place.dto.response.PlaceDetailIntegratedResponseDto;
+import com.comma.soomteum.domain.place.dto.response.PlaceDetailResponseDto;
+import com.comma.soomteum.domain.tour.service.RecommendPlacesService;
+import com.comma.soomteum.domain.userPlace.enums.UserActionType;
+import com.comma.soomteum.domain.userPlace.service.UserPlaceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PlaceDetailIntegratedService {
+
+    private final KorDetailService korDetailService;
+    private final RecommendPlacesService recommendPlacesService;
+    private final UserPlaceService userPlaceService;
+    private final AiReviewService aiReviewService;
+    private final PublicParkingService publicParkingService;
+
+    private static final String GANGNEUNG_REGION_CODE = "32230";
+    private static final String GANGNEUNG_AREA_CODE = "32";
+    private static final int DEFAULT_PARKING_LIMIT = 5;
+
+    public Mono<PlaceDetailIntegratedResponseDto> getIntegratedPlaceDetail(String contentId) {
+        return korDetailService.getDetail(
+                TourApiRequestDto.DetailCommon2.builder()
+                        .contentId(contentId)
+                        .build())
+                .flatMap(placeDetail -> {
+                    if (placeDetail.getBody() == null || 
+                        placeDetail.getBody().getItems() == null || 
+                        placeDetail.getBody().getItems().getItem() == null ||
+                        placeDetail.getBody().getItems().getItem().isEmpty()) {
+                        return Mono.error(new RuntimeException("여행지 정보를 찾을 수 없습니다."));
+                    }
+
+                    PlaceDetailResponseDto.Item item = placeDetail.getBody().getItems().getItem().get(0);
+                    
+                    return buildIntegratedResponse(contentId, item);
+                });
+    }
+
+    private Mono<PlaceDetailIntegratedResponseDto> buildIntegratedResponse(String contentId, PlaceDetailResponseDto.Item item) {
+        PlaceDetailIntegratedResponseDto.PlaceDetailIntegratedResponseDtoBuilder builder = 
+                PlaceDetailIntegratedResponseDto.builder()
+                        .placeName(item.getTitle())
+                        .placeImageUrl(item.getFirstimage())
+                        .placeAddress(item.getAddr1())
+                        .introduction(item.getOverview())
+                        .longitude(item.getMapx())
+                        .latitude(item.getMapy());
+
+        // 좋아요 수 조회
+        try {
+            long likeCount = userPlaceService.getActionCountByContentId(contentId, UserActionType.LIKE);
+            builder.likeCount(likeCount);
+        } catch (Exception e) {
+            log.warn("좋아요 수 조회 실패: contentId={}", contentId, e);
+            builder.likeCount(0L);
+        }
+
+        // 한적함 등급 조회 (비동기)
+        return getTranquilityLevel(contentId, item.getMapx(), item.getMapy())
+                .flatMap(tranquilityLevel -> {
+                    builder.tranquilityLevel(tranquilityLevel);
+                    
+                    // 지역 정보 설정 및 강릉시 전용 기능 처리
+                    return processRegionSpecificFeatures(builder, item, contentId);
+                });
+    }
+
+    private Mono<Integer> getTranquilityLevel(String contentId, String longitude, String latitude) {
+        if (longitude == null || latitude == null) {
+            return Mono.just(-1);
+        }
+
+        try {
+            return recommendPlacesService.recommendPlaces(
+                    TourApiRequestDto.LocationBasedList2.builder()
+                            .mapX(Double.parseDouble(longitude))
+                            .mapY(Double.parseDouble(latitude))
+                            .radius(1000)
+                            .build())
+                    .filter(item -> contentId.equals(item.getContentid()))
+                    .next()
+                    .map(item -> {
+                        String cnctrRate = item.getCnctrRate();
+                        if (cnctrRate != null && !"-1".equals(cnctrRate)) {
+                            try {
+                                return Integer.parseInt(cnctrRate);
+                            } catch (NumberFormatException e) {
+                                log.warn("한적함 등급 파싱 실패: {}", cnctrRate);
+                                return -1;
+                            }
+                        }
+                        return -1;
+                    })
+                    .defaultIfEmpty(-1);
+        } catch (Exception e) {
+            log.warn("한적함 등급 조회 실패: contentId={}", contentId, e);
+            return Mono.just(-1);
+        }
+    }
+
+    private Mono<PlaceDetailIntegratedResponseDto> processRegionSpecificFeatures(
+            PlaceDetailIntegratedResponseDto.PlaceDetailIntegratedResponseDtoBuilder builder,
+            PlaceDetailResponseDto.Item item, String contentId) {
+        
+        // 지역 정보 추출 (주소에서)
+        String region = extractRegionFromAddress(item.getAddr1());
+        builder.region(region);
+
+        // 테마 정보는 별도 서비스에서 조회해야 함 (현재는 기본값 설정)
+        builder.theme("관광지");
+
+        // 강릉시인 경우에만 AI 꿀팁과 주차장 정보 추가
+        if (isGangneungRegion(region)) {
+            return addGangneungSpecificFeatures(builder, item, contentId);
+        }
+
+        return Mono.just(builder.build());
+    }
+
+    private String extractRegionFromAddress(String address) {
+        if (address == null) return "정보없음";
+        
+        if (address.contains("강릉시")) return "강릉시";
+        if (address.contains("속초시")) return "속초시";
+        if (address.contains("동해시")) return "동해시";
+        // 추가 지역 매핑 필요시 여기에 추가
+        
+        return "기타";
+    }
+
+    private boolean isGangneungRegion(String region) {
+        return "강릉시".equals(region);
+    }
+
+    private Mono<PlaceDetailIntegratedResponseDto> addGangneungSpecificFeatures(
+            PlaceDetailIntegratedResponseDto.PlaceDetailIntegratedResponseDtoBuilder builder,
+            PlaceDetailResponseDto.Item item, String contentId) {
+        
+        // AI 꿀팁 조회
+        String aiTipSummary = getAiTipSummary(item.getTitle());
+        builder.aiTipSummary(aiTipSummary);
+
+        // 주변 주차장 정보 조회
+        List<PublicParkingResponseDto> nearbyParking = getNearbyParking(item.getMapx(), item.getMapy());
+        builder.nearbyParkingLots(nearbyParking);
+
+        return Mono.just(builder.build());
+    }
+
+    private String getAiTipSummary(String placeName) {
+        if (placeName == null || placeName.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+            AiReviewRequest request = new AiReviewRequest(placeName);
+            AiReviewResponse response = aiReviewService.summarizeByPlaceName(request);
+            return response.getSummaryText();
+        } catch (Exception e) {
+            log.warn("AI 꿀팁 조회 실패: placeName={}", placeName, e);
+            return null;
+        }
+    }
+
+    private List<PublicParkingResponseDto> getNearbyParking(String longitude, String latitude) {
+        if (longitude == null || latitude == null) {
+            return null;
+        }
+
+        try {
+            BigDecimal lat = new BigDecimal(latitude);
+            BigDecimal lon = new BigDecimal(longitude);
+            return publicParkingService.findNearbyParking(lat, lon, GANGNEUNG_REGION_CODE, DEFAULT_PARKING_LIMIT);
+        } catch (Exception e) {
+            log.warn("주변 주차장 조회 실패: longitude={}, latitude={}", longitude, latitude, e);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #60 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 여행지 상세 정보를 한 번의 API 호출로 통합 조회할 수 있는 PlaceDetailIntegratedService를 구현했습니다.
- 여행지 기본 정보, 사용자별 좋아요/저장 상태, 리뷰 목록, 주변 주차장 정보를 하나의 응답으로 제공합니다.   

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- PlaceDetailIntegratedService 클래스 구현                                                                                                                                                         - 여행지 기본 정보 조회                                                                                                                                                                           - 사용자별 좋아요/저장 상태 조회                                                                                                                                                                  - 리뷰 목록 조회 (평균 평점 포함)                                                                                                                                                                 - 강릉시 여행지 한정 주변 주차장 정보 제공                                                                                                                                                        - PlaceDetailIntegratedDto 응답 DTO 구현                                                                                                                                                            - PlaceController에 `/api/places/{id}/integrated` 엔드포인트 추가                                                                                                                                   - 통합 조회 API를 위한 테스트 및 검증       

## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="1073" height="532" alt="image" src="https://github.com/user-attachments/assets/13b4fa2f-d3f0-4023-8647-2d747d3d161f" />
<img width="1058" height="361" alt="image" src="https://github.com/user-attachments/assets/58c59b00-7d1b-4836-be26-223f52a6d673" />

## 📝 참고
- 한적한 등급이 -2로 오는 이슈
- #59, #61 기능 구현 완료 후 수정 예정