### PR TITLE
[Feat/#61] 지역 기반 혼잡도 받아오기 추가

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/src/main/java/com/comma/soomteum/domain/parking/controller/DebugController.java
+++ b/src/main/java/com/comma/soomteum/domain/parking/controller/DebugController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
 
-@Tag(name = "디버그", description = "데이터 확인용 API (개발환경에서만 사용)")
+@Tag(name = "디버그- parking", description = "데이터 확인용 API (개발환경에서만 사용)")
 @RestController
 @RequestMapping("/api/debug")
 @RequiredArgsConstructor

--- a/src/main/java/com/comma/soomteum/domain/place/controller/KorService2Controller.java
+++ b/src/main/java/com/comma/soomteum/domain/place/controller/KorService2Controller.java
@@ -21,9 +21,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
-@Tag(name = "KOR Service2", description = "한국관광공사 OpenAPI 연동")
+@Tag(name = "디버그- KorService2", description = "한국관광공사 데이터 확인용 API (개발환경에서만 사용)")
 @RestController
-@RequestMapping(path = "/api/kor", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(path = "/api/debug", produces = MediaType.APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
 @Validated
 public class KorService2Controller {

--- a/src/main/java/com/comma/soomteum/domain/place/service/PlaceDetailIntegratedService.java
+++ b/src/main/java/com/comma/soomteum/domain/place/service/PlaceDetailIntegratedService.java
@@ -8,7 +8,7 @@ import com.comma.soomteum.domain.parking.service.PublicParkingService;
 import com.comma.soomteum.domain.place.dto.TourApiRequestDto;
 import com.comma.soomteum.domain.place.dto.response.PlaceDetailIntegratedResponseDto;
 import com.comma.soomteum.domain.place.dto.response.PlaceDetailResponseDto;
-import com.comma.soomteum.domain.tour.service.RecommendPlacesService;
+import com.comma.soomteum.domain.tour.service.TourService;
 import com.comma.soomteum.domain.userPlace.enums.UserActionType;
 import com.comma.soomteum.domain.userPlace.service.UserPlaceService;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +25,7 @@ import java.util.List;
 public class PlaceDetailIntegratedService {
 
     private final KorDetailService korDetailService;
-    private final RecommendPlacesService recommendPlacesService;
+    private final TourService recommendPlacesService;
     private final UserPlaceService userPlaceService;
     private final AiReviewService aiReviewService;
     private final PublicParkingService publicParkingService;
@@ -88,7 +88,7 @@ public class PlaceDetailIntegratedService {
         }
 
         try {
-            return recommendPlacesService.recommendPlaces(
+            return recommendPlacesService.locationPlaces(
                     TourApiRequestDto.LocationBasedList2.builder()
                             .mapX(Double.parseDouble(longitude))
                             .mapY(Double.parseDouble(latitude))

--- a/src/main/java/com/comma/soomteum/domain/tour/controller/TourController.java
+++ b/src/main/java/com/comma/soomteum/domain/tour/controller/TourController.java
@@ -3,7 +3,7 @@ package com.comma.soomteum.domain.tour.controller;
 import com.comma.soomteum.domain.ai.adapter.AiServiceAdapter;
 import com.comma.soomteum.domain.place.dto.TatsCnctrResponse;
 import com.comma.soomteum.domain.place.dto.TourApiRequestDto;
-import com.comma.soomteum.domain.tour.service.RecommendPlacesService;
+import com.comma.soomteum.domain.tour.service.TourService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,14 +19,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
 
-@Tag(name = "Recommended Places", description = "한적한 장소 추천 API")
+@Tag(name = "AI & Area Recommended Places", description = "최종 장소 추천 API 2개")
 @RestController
 @RequestMapping(path = "/api/places", produces = MediaType.APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
 @Validated
-public class RecommendPlacesController {
+public class TourController {
     private final AiServiceAdapter aiServiceAdapter;
-    private final RecommendPlacesService recommendPlacesService;
+    private final TourService recommendPlacesService;
 
     @Operation(
             summary = "위치 기반 한적한 장소 추천",
@@ -41,10 +41,33 @@ public class RecommendPlacesController {
                             content = @Content(schema = @Schema(implementation = TatsCnctrResponse.TatsCnctrResponseDto.class)))
             }
     )
-    @GetMapping("")
-    public Flux<TatsCnctrResponse.TatsCnctrResponseDto> recommendPlaces(
+    @GetMapping("/ai")
+    public Flux<TatsCnctrResponse.TatsCnctrResponseDto> locationRecommendPlaces(
             @Valid @ParameterObject TourApiRequestDto.LocationBasedList2 req
     ) {
-        return recommendPlacesService.recommendPlaces(req);
+        return recommendPlacesService.locationPlaces(req);
     }
+
+    @Operation(
+            summary = "지역 기반 한적한 장소 추천",
+            description = """
+                    각 장소의 한적함 점수(cnctrRate)를 포함하여 반환합니다.
+                    - `cnctrRate`는 관광객 혼잡도를 나타내는 지수로, -1은 데이터가 없음을 의미합니다.
+                    - 정렬(arrange) 기본값: O=제목순, Q=수정일순, R=등록일순, S=거리순
+                    - `cat1`, `cat2`를 통해 장소 분류 코드로 필터링할 수 있습니다.
+                    """,
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공",
+                            content = @Content(schema = @Schema(implementation = TatsCnctrResponse.TatsCnctrResponseDto.class)))
+            }
+    )
+    @GetMapping("")
+    public Flux<TatsCnctrResponse.TatsCnctrResponseDto> AreaRecommendPlaces(
+            @Valid @ParameterObject TourApiRequestDto.AreaBasedList2 req
+    ) {
+        return recommendPlacesService.AreaPlaces(req);
+    }
+
+
+
 }

--- a/src/main/java/com/comma/soomteum/domain/tour/service/TourService.java
+++ b/src/main/java/com/comma/soomteum/domain/tour/service/TourService.java
@@ -5,6 +5,7 @@ import com.comma.soomteum.domain.place.dto.KorService2Response;
 import com.comma.soomteum.domain.place.dto.TatsCnctrResponse;
 import com.comma.soomteum.domain.place.dto.TourApiRequestDto;
 import com.comma.soomteum.domain.ai.dto.AiRecommendationRequest; // AI 요청 DTO 임포트
+import com.comma.soomteum.domain.place.service.KorAreaService;
 import com.comma.soomteum.domain.place.service.KorLocationService;
 import com.comma.soomteum.domain.place.service.TatsCnctrService;
 import lombok.RequiredArgsConstructor;
@@ -16,13 +17,14 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class RecommendPlacesService {
+public class TourService {
 
     private final KorLocationService korLocationService;
+    private final KorAreaService korAreaService;
     private final TatsCnctrService tatsCnctrService;
     private final AiServiceAdapter aiServiceAdapter;
 
-    public Flux<TatsCnctrResponse.TatsCnctrResponseDto> recommendPlaces(TourApiRequestDto.LocationBasedList2 request) {
+    public Flux<TatsCnctrResponse.TatsCnctrResponseDto> locationPlaces(TourApiRequestDto.LocationBasedList2 request) {
         return korLocationService.locationBasedList(request)
                 .flatMapMany(response -> Flux.fromIterable(response.getBody().getItems().getItem()))
                 .flatMap(this::addCnctrRateToPlace)
@@ -50,6 +52,41 @@ public class RecommendPlacesService {
                 // 5. 정렬한 최종 리스트를 다시 스트림(Flux)으로 변환
                 .flatMapMany(Flux::fromIterable)
                 // 6. AI 출력 DTO(AiRecommendationResponse)를 최종 DTO(TatsCnctrResponseDto)로 변환
+                .map(aiResponse -> {
+                    TatsCnctrResponse.TatsCnctrResponseDto finalDto = new TatsCnctrResponse.TatsCnctrResponseDto();
+                    finalDto.setTitle(aiResponse.getTitle());
+                    finalDto.setContentid(aiResponse.getContentid());
+                    finalDto.setCat1(aiResponse.getCat1());
+                    finalDto.setCat2(aiResponse.getCat2());
+                    finalDto.setFirstimage(aiResponse.getFirstimage());
+                    finalDto.setDist(aiResponse.getDist());
+                    finalDto.setCnctrRate(aiResponse.getCnctrRate());
+                    return finalDto;
+                });
+    }
+
+    public Flux<TatsCnctrResponse.TatsCnctrResponseDto> AreaPlaces(TourApiRequestDto.AreaBasedList2 request) {
+        return korAreaService.areaBasedList(request)
+                .flatMapMany(response -> Flux.fromIterable(response.getBody().getItems().getItem()))
+                .flatMap(this::addCnctrRateToPlace)
+                .collectList()
+                .flatMap(candidateList -> Mono.fromCallable(() -> {
+
+                    List<AiRecommendationRequest> aiRequestItems = candidateList.stream()
+                            .map(dto -> new AiRecommendationRequest(
+                                    dto.getTitle(),
+                                    dto.getContentid(),
+                                    dto.getCat1(),
+                                    dto.getCat2(),
+                                    dto.getFirstimage(),
+                                    dto.getDist(),
+                                    dto.getCnctrRate()
+                            ))
+                            .collect(Collectors.toList());
+
+                    return aiServiceAdapter.createRankedRecommendations(aiRequestItems);
+                }))
+                .flatMapMany(Flux::fromIterable)
                 .map(aiResponse -> {
                     TatsCnctrResponse.TatsCnctrResponseDto finalDto = new TatsCnctrResponse.TatsCnctrResponseDto();
                     finalDto.setTitle(aiResponse.getTitle());


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #61

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 기존의 지역 기반 장소 추천 API에서 혼잡도를 추가하여 완성했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
  - 컨트롤러/서비스 리팩토링: RecommendPlacesController → TourController, RecommendPlacesService → TourService로 클래스명 변경 (기존의 RecommendPlaces가 이름이 길기도 해서 혼잡도까지 추가한 버전이 Tour~로 되게 바꿨습니다.)
  - 지역 기반 추천 API 구현: AreaRecommendPlaces 메서드 추가하여 korAreaService를 활용한 지역 기반 장소 검색 기능 완성
  - API 엔드포인트 정리:
    - /api/places/ai: 위치 기반 AI 추천 (기존 기능)
    - /api/places: 지역 기반 추천 (신규 기능)
  - 통합 서비스 수정: PlaceDetailIntegratedService에서 변경된 메서드명(locationPlaces) 적용

## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="1421" height="4698" alt="image" src="https://github.com/user-attachments/assets/2a93f305-c45b-4d66-a17c-7b85fdddbe56" />
