### PR TITLE
Feat/#59 추천 여행지 혼잡도 랭킹 로직 추가

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/ai/dto/AiRecommendationResponse.java
+++ b/src/main/java/com/comma/soomteum/domain/ai/dto/AiRecommendationResponse.java
@@ -1,8 +1,13 @@
 package com.comma.soomteum.domain.ai.dto;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.Value;
 
-@Value
+@Getter
+@Setter
+@NoArgsConstructor
 public class AiRecommendationResponse {
     String title;
     String contentid;
@@ -11,5 +16,5 @@ public class AiRecommendationResponse {
     String firstimage;
     String dist;
     String cnctrRate;
-    //Integer rank; //1-5단계?
+    int congestionLevel; //여행지 rank 추가
 }

--- a/src/main/java/com/comma/soomteum/domain/ai/service/AiRecommendationService.java
+++ b/src/main/java/com/comma/soomteum/domain/ai/service/AiRecommendationService.java
@@ -122,7 +122,7 @@ public class AiRecommendationService {
     // 추가: 혼잡도 랭킹을 결정하는 헬퍼 메소드
     private int determineCongestionLevel(double rateValue) {
         if (rateValue < 0) { // 데이터가 없는 경우 (-1, -2 등)
-            return 5; // 정보 없으면 레벨 5로 기본 설정 or 아예 0으로 설정?
+            return -1; // (수정)정보 없으면 레벨 -1로 설정
         }
         if (rateValue <= CONGESTION_LEVEL_1_THRESHOLD) {
             return 1; // 레벨 1: 쾌적

--- a/src/main/java/com/comma/soomteum/domain/ai/service/AiRecommendationService.java
+++ b/src/main/java/com/comma/soomteum/domain/ai/service/AiRecommendationService.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Service
 public class AiRecommendationService {
@@ -23,12 +24,17 @@ public class AiRecommendationService {
     private static final double SHRINKAGE_LAMBDA = 0.7;
     private static final double MAX_SHARPNESS = 10.0;
     private static final double MIN_SHARPNESS = 0.01;
+    // 절대적 혼잡도 레벨 기준
+    private static final double CONGESTION_LEVEL_1_THRESHOLD = 30.0; // 쾌적
+    private static final double CONGESTION_LEVEL_2_THRESHOLD = 70.0; // 보통
+    private static final double CONGESTION_LEVEL_3_THRESHOLD = 90.0; // 붐빔
 
 
     public List<AiRecommendationResponse> createRankedRecommendations(List<AiRecommendationRequest> items) {
         if (items == null || items.isEmpty()) {
             return Collections.emptyList();
         }
+
 
         // --- 데이터 준비 및 동적 샤프니스 계산 ---
         double[] sortedDists = items.stream().mapToDouble(item -> parseDouble(item.getDist())).sorted().toArray();
@@ -57,7 +63,6 @@ public class AiRecommendationService {
         validCongestionScores.sort(Double::compare);
         double dynamicPenalty = validCongestionScores.isEmpty() ? FIXED_PENALTY_SCORE : findQuantile(validCongestionScores, 0.2);
         double finalPenaltyScore = (SHRINKAGE_LAMBDA * FIXED_PENALTY_SCORE) + ((1 - SHRINKAGE_LAMBDA) * dynamicPenalty);
-
 
         // --- 최종 점수 계산 ---
         List<ScoredItem> scoredItems = new ArrayList<>();
@@ -88,15 +93,23 @@ public class AiRecommendationService {
         List<AiRecommendationResponse> rankedItems = scoredItems.stream()
                 .map(scoredItem -> {
                     AiRecommendationRequest original = scoredItem.originalItem();
-                    return new AiRecommendationResponse(
-                            original.getTitle(),
-                            original.getContentid(),
-                            original.getCat1(),
-                            original.getCat2(),
-                            original.getFirstimage(),
-                            original.getDist(),
-                            original.getCnctrRate()
-                    );
+
+                    // 추가: 각 아이템의 혼잡도 랭킹 계산
+                    double rateValue = parseDouble(original.getCnctrRate());
+                    int level = determineCongestionLevel(rateValue);
+
+                    AiRecommendationResponse dto = new AiRecommendationResponse();
+
+                    dto.setTitle(original.getTitle());
+                    dto.setContentid(original.getContentid());
+                    dto.setCat1(original.getCat1());
+                    dto.setCat2(original.getCat2());
+                    dto.setFirstimage(original.getFirstimage());
+                    dto.setDist(original.getDist());
+                    dto.setCnctrRate(original.getCnctrRate());
+                    dto.setCongestionLevel(level);
+                    System.out.println(dto.getCongestionLevel());
+                    return dto;
                 })
                 .collect(Collectors.toList());
 
@@ -105,6 +118,23 @@ public class AiRecommendationService {
 
 
     // --- 헬퍼 메소드들 ---
+
+    // 추가: 혼잡도 랭킹을 결정하는 헬퍼 메소드
+    private int determineCongestionLevel(double rateValue) {
+        if (rateValue < 0) { // 데이터가 없는 경우 (-1, -2 등)
+            return -1; // 레벨 0: 정보 없음
+        }
+        if (rateValue <= CONGESTION_LEVEL_1_THRESHOLD) {
+            return 1; // 레벨 1: 쾌적
+        } else if (rateValue <= CONGESTION_LEVEL_2_THRESHOLD) {
+            return 2; // 레벨 2: 보통
+        } else if (rateValue <= CONGESTION_LEVEL_3_THRESHOLD) {
+            return 3; // 레벨 3: 붐빔
+        } else {
+            return 4; // 레벨 4: 매우 붐빔
+        }
+    }
+
     private double parseDouble(String value) {
         try {
             return Double.parseDouble(value);

--- a/src/main/java/com/comma/soomteum/domain/ai/service/AiRecommendationService.java
+++ b/src/main/java/com/comma/soomteum/domain/ai/service/AiRecommendationService.java
@@ -25,9 +25,10 @@ public class AiRecommendationService {
     private static final double MAX_SHARPNESS = 10.0;
     private static final double MIN_SHARPNESS = 0.01;
     // 절대적 혼잡도 레벨 기준
-    private static final double CONGESTION_LEVEL_1_THRESHOLD = 30.0; // 쾌적
-    private static final double CONGESTION_LEVEL_2_THRESHOLD = 70.0; // 보통
-    private static final double CONGESTION_LEVEL_3_THRESHOLD = 90.0; // 붐빔
+    private static final double CONGESTION_LEVEL_1_THRESHOLD = 20.0; // 쾌적
+    private static final double CONGESTION_LEVEL_2_THRESHOLD = 40.0; // 보통
+    private static final double CONGESTION_LEVEL_3_THRESHOLD = 60.0; // 붐빔
+    private static final double CONGESTION_LEVEL_4_THRESHOLD = 80.0; // 많이붐빔
 
 
     public List<AiRecommendationResponse> createRankedRecommendations(List<AiRecommendationRequest> items) {
@@ -108,7 +109,6 @@ public class AiRecommendationService {
                     dto.setDist(original.getDist());
                     dto.setCnctrRate(original.getCnctrRate());
                     dto.setCongestionLevel(level);
-                    System.out.println(dto.getCongestionLevel());
                     return dto;
                 })
                 .collect(Collectors.toList());
@@ -122,7 +122,7 @@ public class AiRecommendationService {
     // 추가: 혼잡도 랭킹을 결정하는 헬퍼 메소드
     private int determineCongestionLevel(double rateValue) {
         if (rateValue < 0) { // 데이터가 없는 경우 (-1, -2 등)
-            return -1; // 레벨 0: 정보 없음
+            return 5; // 정보 없으면 레벨 5로 기본 설정 or 아예 0으로 설정?
         }
         if (rateValue <= CONGESTION_LEVEL_1_THRESHOLD) {
             return 1; // 레벨 1: 쾌적
@@ -130,8 +130,10 @@ public class AiRecommendationService {
             return 2; // 레벨 2: 보통
         } else if (rateValue <= CONGESTION_LEVEL_3_THRESHOLD) {
             return 3; // 레벨 3: 붐빔
-        } else {
+        } else if (rateValue <= CONGESTION_LEVEL_4_THRESHOLD){
             return 4; // 레벨 4: 매우 붐빔
+        } else {
+            return 5; // 레벨 5: 매우매우 붐빔
         }
     }
 

--- a/src/main/java/com/comma/soomteum/domain/place/dto/TatsCnctrResponse.java
+++ b/src/main/java/com/comma/soomteum/domain/place/dto/TatsCnctrResponse.java
@@ -62,6 +62,7 @@ public class TatsCnctrResponse {
         private String firstimage;
         private String dist;
         private String cnctrRate;
+        private int congestionLevel;
     }
 }
 

--- a/src/main/java/com/comma/soomteum/domain/tour/service/RecommendPlacesService.java
+++ b/src/main/java/com/comma/soomteum/domain/tour/service/RecommendPlacesService.java
@@ -59,6 +59,7 @@ public class RecommendPlacesService {
                     finalDto.setFirstimage(aiResponse.getFirstimage());
                     finalDto.setDist(aiResponse.getDist());
                     finalDto.setCnctrRate(aiResponse.getCnctrRate());
+                    finalDto.setCongestionLevel(aiResponse.getCongestionLevel());
                     return finalDto;
                 });
     }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #59 

## 🌱 PR 요약
추천된 여행지 각각의 혼잡도를 고려하여 랭크(1~5)를 매기는 로직을 추가하였습니다.


## 🛠 작업 내용
* AiRecommendationResponse DTO에 congestionLevel 필드를 추가하여 반환하였습니다.
* AiRecommendationService에 determineCongestionLevel 헬퍼 메소드를 추가하여 랭크를 계산하였습니다.

## 📸 상세 이미지
<img width="655" height="367" alt="image" src="https://github.com/user-attachments/assets/aca2e5e7-f695-4c2e-82d3-21dbc3e68914" />
