### PR TITLE
[Refactor/#65] (일반) 여행지 탐색에 한적함 등급 추가

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/ai/dto/AiRecommendationResponse.java
+++ b/src/main/java/com/comma/soomteum/domain/ai/dto/AiRecommendationResponse.java
@@ -16,5 +16,5 @@ public class AiRecommendationResponse {
     String firstimage;
     String dist;
     String cnctrRate;
-    int congestionLevel; //여행지 rank 추가
+    int quietnessLevel; //여행지 rank 추가
 }

--- a/src/main/java/com/comma/soomteum/domain/ai/service/AiRecommendationService.java
+++ b/src/main/java/com/comma/soomteum/domain/ai/service/AiRecommendationService.java
@@ -24,11 +24,11 @@ public class AiRecommendationService {
     private static final double SHRINKAGE_LAMBDA = 0.7;
     private static final double MAX_SHARPNESS = 10.0;
     private static final double MIN_SHARPNESS = 0.01;
-    // 절대적 혼잡도 레벨 기준
-    private static final double CONGESTION_LEVEL_1_THRESHOLD = 20.0; // 쾌적
-    private static final double CONGESTION_LEVEL_2_THRESHOLD = 40.0; // 보통
-    private static final double CONGESTION_LEVEL_3_THRESHOLD = 60.0; // 붐빔
-    private static final double CONGESTION_LEVEL_4_THRESHOLD = 80.0; // 많이붐빔
+    // 절대적 한적함 레벨 기준
+    private static final double QUIETNESS_LEVEL_1_THRESHOLD = 20.0; // 쾌적
+    private static final double QUIETNESS_LEVEL_2_THRESHOLD = 40.0; // 보통
+    private static final double QUIETNESS_LEVEL_3_THRESHOLD = 60.0; // 붐빔
+    private static final double QUIETNESS_LEVEL_4_THRESHOLD = 80.0; // 많이붐빔
 
 
     public List<AiRecommendationResponse> createRankedRecommendations(List<AiRecommendationRequest> items) {
@@ -95,9 +95,9 @@ public class AiRecommendationService {
                 .map(scoredItem -> {
                     AiRecommendationRequest original = scoredItem.originalItem();
 
-                    // 추가: 각 아이템의 혼잡도 랭킹 계산
+                    // 추가: 각 아이템의 한적함 랭킹 계산
                     double rateValue = parseDouble(original.getCnctrRate());
-                    int level = determineCongestionLevel(rateValue);
+                    int level = determineQuietnessLevel(rateValue);
 
                     AiRecommendationResponse dto = new AiRecommendationResponse();
 
@@ -108,7 +108,7 @@ public class AiRecommendationService {
                     dto.setFirstimage(original.getFirstimage());
                     dto.setDist(original.getDist());
                     dto.setCnctrRate(original.getCnctrRate());
-                    dto.setCongestionLevel(level);
+                    dto.setQuietnessLevel(level);
                     return dto;
                 })
                 .collect(Collectors.toList());
@@ -119,18 +119,18 @@ public class AiRecommendationService {
 
     // --- 헬퍼 메소드들 ---
 
-    // 추가: 혼잡도 랭킹을 결정하는 헬퍼 메소드
-    private int determineCongestionLevel(double rateValue) {
+    // 추가: 한적함 랭킹을 결정하는 헬퍼 메소드
+    private int determineQuietnessLevel(double rateValue) {
         if (rateValue < 0) { // 데이터가 없는 경우 (-1, -2 등)
             return -1; // (수정)정보 없으면 레벨 -1로 설정
         }
-        if (rateValue <= CONGESTION_LEVEL_1_THRESHOLD) {
+        if (rateValue <= QUIETNESS_LEVEL_1_THRESHOLD) {
             return 1; // 레벨 1: 쾌적
-        } else if (rateValue <= CONGESTION_LEVEL_2_THRESHOLD) {
+        } else if (rateValue <= QUIETNESS_LEVEL_2_THRESHOLD) {
             return 2; // 레벨 2: 보통
-        } else if (rateValue <= CONGESTION_LEVEL_3_THRESHOLD) {
+        } else if (rateValue <= QUIETNESS_LEVEL_3_THRESHOLD) {
             return 3; // 레벨 3: 붐빔
-        } else if (rateValue <= CONGESTION_LEVEL_4_THRESHOLD){
+        } else if (rateValue <= QUIETNESS_LEVEL_4_THRESHOLD){
             return 4; // 레벨 4: 매우 붐빔
         } else {
             return 5; // 레벨 5: 매우매우 붐빔

--- a/src/main/java/com/comma/soomteum/domain/place/dto/TatsCnctrResponse.java
+++ b/src/main/java/com/comma/soomteum/domain/place/dto/TatsCnctrResponse.java
@@ -62,7 +62,7 @@ public class TatsCnctrResponse {
         private String firstimage;
         private String dist;
         private String cnctrRate;
-        private int congestionLevel;
+        private int quietnessLevel;
     }
 }
 

--- a/src/main/java/com/comma/soomteum/domain/tour/service/TourService.java
+++ b/src/main/java/com/comma/soomteum/domain/tour/service/TourService.java
@@ -97,6 +97,7 @@ public class TourService {
                     finalDto.setFirstimage(aiResponse.getFirstimage());
                     finalDto.setDist(aiResponse.getDist());
                     finalDto.setCnctrRate(aiResponse.getCnctrRate());
+                    finalDto.setCongestionLevel(aiResponse.getCongestionLevel());
                     return finalDto;
                 });
     }

--- a/src/main/java/com/comma/soomteum/domain/tour/service/TourService.java
+++ b/src/main/java/com/comma/soomteum/domain/tour/service/TourService.java
@@ -61,7 +61,7 @@ public class TourService {
                     finalDto.setFirstimage(aiResponse.getFirstimage());
                     finalDto.setDist(aiResponse.getDist());
                     finalDto.setCnctrRate(aiResponse.getCnctrRate());
-                    finalDto.setCongestionLevel(aiResponse.getCongestionLevel());
+                    finalDto.setQuietnessLevel(aiResponse.getQuietnessLevel());
                     return finalDto;
                 });
     }
@@ -97,7 +97,7 @@ public class TourService {
                     finalDto.setFirstimage(aiResponse.getFirstimage());
                     finalDto.setDist(aiResponse.getDist());
                     finalDto.setCnctrRate(aiResponse.getCnctrRate());
-                    finalDto.setCongestionLevel(aiResponse.getCongestionLevel());
+                    finalDto.setQuietnessLevel(aiResponse.getQuietnessLevel());
                     return finalDto;
                 });
     }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #65

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 여행지 한적함 등급 기능 개선 및 네이밍 리팩토링
-
## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
  - 여행지 한적함 등급 추가: TourService.AreaPlaces 메서드에 누락된
  quietnessLevel 필드 설정 추가
  - 네이밍 리팩토링: 혼잡도를 의미하던 congestionLevel을 한적함을 의미하는
  quietnessLevel로 일관성 있게 변경
    - AiRecommendationResponse.java: 필드명 변경
    - AiRecommendationService.java: 메서드명, 상수명, 주석 등 모든 관련 부분
  변경
    - TatsCnctrResponse.java: DTO 필드명 변경
    - TourService.java: 두 메서드에서 필드 설정 코드 변경
  - 기능 동등성 보장: AreaPlaces와 locationPlaces 메서드가 동일한 응답 구조를
  갖도록 수정

## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="1412" height="5172" alt="image" src="https://github.com/user-attachments/assets/ceced09f-f18f-431d-a281-3500d1fe0ce9" />
