### PR TITLE
[Fix/#67] 여행지 상세 통합 조회 API에서 한적함 등급이 -2로 반환되는 이슈 수정

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/place/service/PlaceDetailIntegratedService.java
+++ b/src/main/java/com/comma/soomteum/domain/place/service/PlaceDetailIntegratedService.java
@@ -2,9 +2,11 @@ package com.comma.soomteum.domain.place.service;
 
 import com.comma.soomteum.domain.ai.dto.AiReviewRequest;
 import com.comma.soomteum.domain.ai.dto.AiReviewResponse;
+import com.comma.soomteum.domain.ai.service.AiRecommendationService;
 import com.comma.soomteum.domain.ai.service.AiReviewService;
 import com.comma.soomteum.domain.parking.dto.PublicParkingResponseDto;
 import com.comma.soomteum.domain.parking.service.PublicParkingService;
+import com.comma.soomteum.domain.place.dto.KorService2Response;
 import com.comma.soomteum.domain.place.dto.TourApiRequestDto;
 import com.comma.soomteum.domain.place.dto.response.PlaceDetailIntegratedResponseDto;
 import com.comma.soomteum.domain.place.dto.response.PlaceDetailResponseDto;
@@ -28,6 +30,7 @@ public class PlaceDetailIntegratedService {
     private final TourService recommendPlacesService;
     private final UserPlaceService userPlaceService;
     private final AiReviewService aiReviewService;
+    private final AiRecommendationService aiRecommendationService;
     private final PublicParkingService publicParkingService;
 
     private static final String GANGNEUNG_REGION_CODE = "32230";
@@ -73,7 +76,7 @@ public class PlaceDetailIntegratedService {
         }
 
         // 한적함 등급 조회 (비동기)
-        return getTranquilityLevel(contentId, item.getMapx(), item.getMapy())
+        return getTranquilityLevel(contentId, item.getTitle(), item.getMapx(), item.getMapy())
                 .flatMap(tranquilityLevel -> {
                     builder.tranquilityLevel(tranquilityLevel);
                     
@@ -82,7 +85,7 @@ public class PlaceDetailIntegratedService {
                 });
     }
 
-    private Mono<Integer> getTranquilityLevel(String contentId, String longitude, String latitude) {
+    private Mono<Integer> getTranquilityLevel(String contentId, String title, String longitude, String latitude) {
         if (longitude == null || latitude == null) {
             return Mono.just(-1);
         }
@@ -98,20 +101,39 @@ public class PlaceDetailIntegratedService {
                     .next()
                     .map(item -> {
                         String cnctrRate = item.getCnctrRate();
-                        if (cnctrRate != null && !"-1".equals(cnctrRate)) {
-                            try {
-                                return Integer.parseInt(cnctrRate);
-                            } catch (NumberFormatException e) {
-                                log.warn("한적함 등급 파싱 실패: {}", cnctrRate);
-                                return -1;
-                            }
-                        }
-                        return -1;
+                        return calculateTranquilityLevel(cnctrRate);
                     })
                     .defaultIfEmpty(-1);
         } catch (Exception e) {
             log.warn("한적함 등급 조회 실패: contentId={}", contentId, e);
             return Mono.just(-1);
+        }
+    }
+
+    private Integer calculateTranquilityLevel(String cnctrRate) {
+        try {
+            double rateValue = (cnctrRate != null) ? Double.parseDouble(cnctrRate) : -1.0;
+            return determineTranquilityLevel(rateValue);
+        } catch (NumberFormatException e) {
+            log.warn("한적함 등급 파싱 실패: {}", cnctrRate);
+            return -1;
+        }
+    }
+
+    private int determineTranquilityLevel(double rateValue) {
+        if (rateValue < 0) {
+            return -1;
+        }
+        if (rateValue <= 20.0) {
+            return 1;
+        } else if (rateValue <= 40.0) {
+            return 2;
+        } else if (rateValue <= 60.0) {
+            return 3;
+        } else if (rateValue <= 80.0) {
+            return 4;
+        } else {
+            return 5;
         }
     }
 


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #67 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- -2가 응답되지 않도록 하고, 실제 한적함 등급을 반환하거나(혼잡도 서비스 연동) 불가 시 -1로 반환하도록 처리

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 메서드 수정
    - getTranquilityLevel(): 기존 TourService 결과를 한적함 등급으로 변환
    - calculateTranquilityLevel(): cnctrRate 문자열을 double로 변환
    - determineTranquilityLevel(): 혼잡도 점수를 1-5 등급으로 변환
 - 등급 기준
    - -1, -2 등 → -1 (데이터 없음)
    - 0-20 → 1 (쾌적)
    - 21-40 → 2 (보통)
    - 41-60 → 3 (붐빔)
    - 61-80 → 4 (매우 붐빔)
    - 81+ → 5 (매우매우 붐빔)


## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="1040" height="284" alt="image" src="https://github.com/user-attachments/assets/998b748b-1a9e-4811-89b3-f86366568f5b" />
