### PR TITLE
[Refactor/#69]  TatsCnctrResponseDto에 필드 추가 및 좋아요 개수 

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/place/dto/TatsCnctrResponse.java
+++ b/src/main/java/com/comma/soomteum/domain/place/dto/TatsCnctrResponse.java
@@ -59,6 +59,10 @@ public class TatsCnctrResponse {
         private String contentid;
         private String cat1;
         private String cat2;
+        private String catName;
+        private Integer areaCode;
+        private Integer sigunguCode;
+        private String areaName;
         private String firstimage;
         private String dist;
         private String cnctrRate;

--- a/src/main/java/com/comma/soomteum/domain/place/dto/TatsCnctrResponse.java
+++ b/src/main/java/com/comma/soomteum/domain/place/dto/TatsCnctrResponse.java
@@ -65,6 +65,7 @@ public class TatsCnctrResponse {
         private String areaName;
         private String firstimage;
         private String dist;
+        private Long likeCount;
         private String cnctrRate;
         private int quietnessLevel;
     }

--- a/src/main/java/com/comma/soomteum/domain/theme/repository/ThemeRepository.java
+++ b/src/main/java/com/comma/soomteum/domain/theme/repository/ThemeRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface ThemeRepository extends JpaRepository<Theme, Long> {
     Optional<Theme> findByName(String name);
+    Optional<Theme> findByCat1AndCat2(String cat1, String cat2);
 }

--- a/src/main/java/com/comma/soomteum/domain/tour/service/TourService.java
+++ b/src/main/java/com/comma/soomteum/domain/tour/service/TourService.java
@@ -8,6 +8,7 @@ import com.comma.soomteum.domain.ai.dto.AiRecommendationRequest; // AI 요청 DT
 import com.comma.soomteum.domain.place.service.KorAreaService;
 import com.comma.soomteum.domain.place.service.KorLocationService;
 import com.comma.soomteum.domain.place.service.TatsCnctrService;
+import com.comma.soomteum.domain.place.service.PlaceService;
 import com.comma.soomteum.domain.theme.repository.ThemeRepository;
 import com.comma.soomteum.domain.region.repository.RegionRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ public class TourService {
     private final AiServiceAdapter aiServiceAdapter;
     private final ThemeRepository themeRepository;
     private final RegionRepository regionRepository;
+    private final PlaceService placeService;
 
     public Flux<TatsCnctrResponse.TatsCnctrResponseDto> locationPlaces(TourApiRequestDto.LocationBasedList2 request) {
         return korLocationService.locationBasedList(request)
@@ -153,6 +155,12 @@ public class TourService {
         if (dto.getCat1() != null && dto.getCat2() != null) {
             themeRepository.findByCat1AndCat2(dto.getCat1(), dto.getCat2())
                     .ifPresent(theme -> dto.setCatName(theme.getName()));
+        }
+        
+        // likeCount 설정
+        if (dto.getContentid() != null) {
+            placeService.findByContentId(dto.getContentid())
+                    .ifPresent(place -> dto.setLikeCount(place.getLikeCount()));
         }
         
         // areaCode, sigunguCode, areaName 설정

--- a/src/main/java/com/comma/soomteum/domain/tour/service/TourService.java
+++ b/src/main/java/com/comma/soomteum/domain/tour/service/TourService.java
@@ -8,6 +8,8 @@ import com.comma.soomteum.domain.ai.dto.AiRecommendationRequest; // AI 요청 DT
 import com.comma.soomteum.domain.place.service.KorAreaService;
 import com.comma.soomteum.domain.place.service.KorLocationService;
 import com.comma.soomteum.domain.place.service.TatsCnctrService;
+import com.comma.soomteum.domain.theme.repository.ThemeRepository;
+import com.comma.soomteum.domain.region.repository.RegionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
@@ -23,6 +25,8 @@ public class TourService {
     private final KorAreaService korAreaService;
     private final TatsCnctrService tatsCnctrService;
     private final AiServiceAdapter aiServiceAdapter;
+    private final ThemeRepository themeRepository;
+    private final RegionRepository regionRepository;
 
     public Flux<TatsCnctrResponse.TatsCnctrResponseDto> locationPlaces(TourApiRequestDto.LocationBasedList2 request) {
         return korLocationService.locationBasedList(request)
@@ -62,6 +66,10 @@ public class TourService {
                     finalDto.setDist(aiResponse.getDist());
                     finalDto.setCnctrRate(aiResponse.getCnctrRate());
                     finalDto.setQuietnessLevel(aiResponse.getQuietnessLevel());
+                    
+                    // 새로운 필드들 설정 (locationPlaces는 areaCode, sigunguCode가 없어서 null 전달)
+                    setCatNameAndAreaInfo(finalDto, null, null);
+                    
                     return finalDto;
                 });
     }
@@ -98,6 +106,10 @@ public class TourService {
                     finalDto.setDist(aiResponse.getDist());
                     finalDto.setCnctrRate(aiResponse.getCnctrRate());
                     finalDto.setQuietnessLevel(aiResponse.getQuietnessLevel());
+                    
+                    // 새로운 필드들 설정
+                    setCatNameAndAreaInfo(finalDto, request.getAreaCode(), request.getSigunguCode());
+                    
                     return finalDto;
                 });
     }
@@ -113,6 +125,10 @@ public class TourService {
                     newDto.setFirstimage(place.getFirstimage());
                     newDto.setDist(place.getDist());
                     newDto.setCnctrRate(tatsCnctrDto.getCnctrRate());
+                    
+                    // 새로운 필드들 설정 (addCnctrRateToPlace는 areaCode, sigunguCode가 없어서 null 전달)
+                    setCatNameAndAreaInfo(newDto, null, null);
+                    
                     return newDto;
                 })
                 .onErrorResume(e -> {
@@ -124,7 +140,31 @@ public class TourService {
                     errorDto.setFirstimage(place.getFirstimage());
                     errorDto.setDist(place.getDist());
                     errorDto.setCnctrRate("-2"); // Default value for error
+                    
+                    // 새로운 필드들 설정 (오류 케이스에서도 catName만 설정)
+                    setCatNameAndAreaInfo(errorDto, null, null);
+                    
                     return Mono.just(errorDto);
                 });
+    }
+
+    private void setCatNameAndAreaInfo(TatsCnctrResponse.TatsCnctrResponseDto dto, Integer areaCode, Integer sigunguCode) {
+        // catName 설정
+        if (dto.getCat1() != null && dto.getCat2() != null) {
+            themeRepository.findByCat1AndCat2(dto.getCat1(), dto.getCat2())
+                    .ifPresent(theme -> dto.setCatName(theme.getName()));
+        }
+        
+        // areaCode, sigunguCode, areaName 설정
+        if (areaCode != null && sigunguCode != null) {
+            dto.setAreaCode(areaCode);
+            dto.setSigunguCode(sigunguCode);
+            
+            // areaName 설정
+            regionRepository.findByKorAreaCodeAndKorSigunguCode(
+                    String.valueOf(areaCode), 
+                    String.valueOf(sigunguCode)
+            ).ifPresent(region -> dto.setAreaName(region.getName()));
+        }
     }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #69

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
  TatsCnctrResponseDto에 새로운 필드들(catName, areaCode,
  sigunguCode, areaName, likeCount)을 추가하고,
  TourService에서 이 필드들이 적절히 설정되도록 구현했습니다.
  또한 PlaceLikeController의 좋아요 개수 조회 기능을
  TourService에 통합하여 여행지 조회 시 좋아요 개수를 함께
  반환하도록 개선했습니다.


## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
  1. DTO 필드 추가

  - TatsCnctrResponseDto에 다음 필드들 추가:
    - catName: 테마 이름
    - areaCode: 지역 코드
    - sigunguCode: 시군구 코드
    - areaName: 지역 이름
    - likeCount: 좋아요 개수

  2. Repository 메소드 추가

  - ThemeRepository에 findByCat1AndCat2() 메소드 추가
  - cat1, cat2 값으로 테마 이름을 조회할 수 있도록 구현

  3. TourService 개선

  - ThemeRepository, RegionRepository, PlaceService 의존성
  추가
  - 모든 메소드(locationPlaces, AreaPlaces,
  addCnctrRateToPlace)에서 새로운 필드 설정 로직 적용
  - setCatNameAndAreaInfo() 헬퍼 메소드 구현:
    - cat1, cat2로 Theme에서 catName 조회 및 설정
    - contentId로 Place에서 likeCount 조회 및 설정
    - areaCode, sigunguCode 설정 (AreaPlaces 메소드만 해당)
    - korAreaCode, korSigunguCode로 Region에서 areaName 조회
  및 설정 (AreaPlaces 메소드만 해당)

  4. 기능 통합

  - PlaceLikeController의 getPlaceLikeCount 기능을
  TourService에 통합
  - 여행지 조회 API 호출 시 별도 API 없이도 좋아요 개수 확인
  가능
  - Place 테이블에 해당 contentId가 존재하는 경우에만
  likeCount 반환


## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="1798" height="5905" alt="image" src="https://github.com/user-attachments/assets/fc47c1b4-7a0d-4153-be13-85a9eb8b4b2e" />
