### PR TITLE
[Fix/#67] 여행지 상세 통합 조회 API 테마 서비스 연동

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/place/dto/CategoryCodeResponse.java
+++ b/src/main/java/com/comma/soomteum/domain/place/dto/CategoryCodeResponse.java
@@ -1,0 +1,58 @@
+package com.comma.soomteum.domain.place.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import lombok.*;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JacksonXmlRootElement(localName = "response")
+@JsonRootName("response")
+public class CategoryCodeResponse {
+
+    private Header header;
+    private Body body;
+
+    @Getter @Setter
+    @NoArgsConstructor @AllArgsConstructor @Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Header {
+        private String resultCode;
+        private String resultMsg;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Body {
+        private Items items;
+        private Integer totalCount;
+        private Integer pageNo;
+        private Integer numOfRows;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Items {
+        @JacksonXmlElementWrapper(useWrapping = false)
+        @JacksonXmlProperty(localName = "item")
+        private List<Item> item;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Item {
+        private String code;
+        private String name;
+        private String rnum;
+    }
+}

--- a/src/main/java/com/comma/soomteum/domain/place/dto/response/PlaceDetailIntegratedResponseDto.java
+++ b/src/main/java/com/comma/soomteum/domain/place/dto/response/PlaceDetailIntegratedResponseDto.java
@@ -27,8 +27,11 @@ public class PlaceDetailIntegratedResponseDto {
     @Schema(description = "여행지 지역", example = "강릉시")
     private String region;
 
-    @Schema(description = "테마 분류", example = "자연관광지")
+    @Schema(description = "테마 분류", example = "A0101")
     private String theme;
+
+    @Schema(description = "테마 분류", example = "자연관광지")
+    private String themeName;
 
     @Schema(description = "한적함 등급 (1-5단계, -1: 데이터 없음)", example = "3")
     private Integer tranquilityLevel;

--- a/src/main/java/com/comma/soomteum/domain/place/service/KorCategoryService.java
+++ b/src/main/java/com/comma/soomteum/domain/place/service/KorCategoryService.java
@@ -1,0 +1,27 @@
+package com.comma.soomteum.domain.place.service;
+
+import com.comma.soomteum.domain.place.dto.CategoryCodeResponse;
+import com.comma.soomteum.domain.place.dto.TourApiRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import static com.comma.soomteum.domain.place.service.KorApiCaller.qpIfPresent;
+
+@Service
+@RequiredArgsConstructor
+public class KorCategoryService {
+
+    private static final String PATH = "/categoryCode2";
+    private final KorApiCaller caller;
+
+    public Mono<CategoryCodeResponse> getCategoryCode(TourApiRequestDto.CategoryCode req) {
+        return caller.get(PATH, b -> {
+            b.queryParam("pageNo", 1)
+                    .queryParam("numOfRows", 100);
+            // 선택 파라미터
+            qpIfPresent(b, "cat1", req.getCat1());
+            qpIfPresent(b, "cat2", req.getCat2());
+        }, CategoryCodeResponse.class);
+    }
+}

--- a/src/main/java/com/comma/soomteum/domain/place/service/PlaceDetailIntegratedService.java
+++ b/src/main/java/com/comma/soomteum/domain/place/service/PlaceDetailIntegratedService.java
@@ -6,6 +6,7 @@ import com.comma.soomteum.domain.ai.service.AiRecommendationService;
 import com.comma.soomteum.domain.ai.service.AiReviewService;
 import com.comma.soomteum.domain.parking.dto.PublicParkingResponseDto;
 import com.comma.soomteum.domain.parking.service.PublicParkingService;
+import com.comma.soomteum.domain.place.dto.CategoryCodeResponse;
 import com.comma.soomteum.domain.place.dto.KorService2Response;
 import com.comma.soomteum.domain.place.dto.TourApiRequestDto;
 import com.comma.soomteum.domain.place.dto.response.PlaceDetailIntegratedResponseDto;
@@ -27,6 +28,7 @@ import java.util.List;
 public class PlaceDetailIntegratedService {
 
     private final KorDetailService korDetailService;
+    private final KorCategoryService korCategoryService;
     private final TourService recommendPlacesService;
     private final UserPlaceService userPlaceService;
     private final AiReviewService aiReviewService;
@@ -75,14 +77,51 @@ public class PlaceDetailIntegratedService {
             builder.likeCount(0L);
         }
 
-        // 한적함 등급 조회 (비동기)
-        return getTranquilityLevel(contentId, item.getTitle(), item.getMapx(), item.getMapy())
-                .flatMap(tranquilityLevel -> {
-                    builder.tranquilityLevel(tranquilityLevel);
-                    
+        // 한적함 등급 및 테마 정보 조회 (비동기)
+        return getTranquilityLevelAndTheme(contentId, item.getTitle(), item.getMapx(), item.getMapy())
+                .flatMap(result -> {
+                    builder.tranquilityLevel(result.getTranquilityLevel());
+                    builder.theme(result.getTheme());
+
                     // 지역 정보 설정 및 강릉시 전용 기능 처리
                     return processRegionSpecificFeatures(builder, item, contentId);
                 });
+    }
+
+    private Mono<TranquilityAndThemeResult> getTranquilityLevelAndTheme(String contentId, String title, String longitude, String latitude) {
+        if (longitude == null || latitude == null) {
+            return Mono.just(new TranquilityAndThemeResult(-1, "정보없음"));
+        }
+
+        try {
+            return recommendPlacesService.locationPlaces(
+                    TourApiRequestDto.LocationBasedList2.builder()
+                            .mapX(Double.parseDouble(longitude))
+                            .mapY(Double.parseDouble(latitude))
+                            .radius(1000)
+                            .build())
+                    .filter(item -> contentId.equals(item.getContentid()))
+                    .next()
+                    .map(item -> {
+                        log.info("locationPlaces에서 받은 item: title={}, contentId={}, cat1={}, cat2={}, cnctrRate={}",
+                                item.getTitle(), item.getContentid(), item.getCat1(), item.getCat2(), item.getCnctrRate());
+
+                        String cnctrRate = item.getCnctrRate();
+                        int tranquilityLevel = calculateTranquilityLevel(cnctrRate);
+
+                        // 테마로 cat2 중분류 코드 반환
+                        String theme = (item.getCat2() != null && !item.getCat2().trim().isEmpty())
+                            ? item.getCat2()
+                            : (item.getCat1() != null ? item.getCat1() : "정보없음");
+
+                        log.info("최종 테마 설정: {}", theme);
+                        return new TranquilityAndThemeResult(tranquilityLevel, theme);
+                    })
+                    .defaultIfEmpty(new TranquilityAndThemeResult(-1, "정보없음"));
+        } catch (Exception e) {
+            log.warn("한적함 등급 및 테마 정보 조회 실패: contentId={}", contentId, e);
+            return Mono.just(new TranquilityAndThemeResult(-1, "정보없음"));
+        }
     }
 
     private Mono<Integer> getTranquilityLevel(String contentId, String title, String longitude, String latitude) {
@@ -145,8 +184,6 @@ public class PlaceDetailIntegratedService {
         String region = extractRegionFromAddress(item.getAddr1());
         builder.region(region);
 
-        // 테마 정보는 별도 서비스에서 조회해야 함 (현재는 기본값 설정)
-        builder.theme("관광지");
 
         // 강릉시인 경우에만 AI 꿀팁과 주차장 정보 추가
         if (isGangneungRegion(region)) {
@@ -213,6 +250,98 @@ public class PlaceDetailIntegratedService {
         } catch (Exception e) {
             log.warn("주변 주차장 조회 실패: longitude={}, latitude={}", longitude, latitude, e);
             return null;
+        }
+    }
+
+    private String determineThemeFromCategories(String cat1, String cat2) {
+        log.info("카테고리 정보 확인: cat1={}, cat2={}", cat1, cat2);
+
+        if (cat1 == null && cat2 == null) {
+            log.warn("cat1과 cat2 모두 null");
+            return "정보없음";
+        }
+
+        try {
+            // cat2(중분류)가 있으면 중분류 이름을 가져오기
+            if (cat2 != null && !cat2.trim().isEmpty()) {
+                log.info("cat2로 카테고리 조회: cat1={}, cat2={}", cat1, cat2);
+                // 특정 cat2의 이름을 얻으려면 cat1과 함께 조회해야 할 수 있음
+                String result = getCategoryNameByCode(cat1, cat2).block();
+                log.info("cat2 조회 결과: {}", result);
+                return result;
+            }
+
+            // cat1(대분류)만 있는 경우
+            if (cat1 != null && !cat1.trim().isEmpty()) {
+                log.info("cat1로 카테고리 조회: {}", cat1);
+                String result = getCategoryNameByCode(cat1, null).block();
+                log.info("cat1 조회 결과: {}", result);
+                return result;
+            }
+
+            log.warn("cat1, cat2 모두 빈 문자열");
+            return "정보없음";
+        } catch (Exception e) {
+            log.warn("카테고리 명칭 조회 실패: cat1={}, cat2={}", cat1, cat2, e);
+            return "정보없음";
+        }
+    }
+
+    private Mono<String> getCategoryNameByCode(String cat1, String cat2) {
+        return korCategoryService.getCategoryCode(
+                TourApiRequestDto.CategoryCode.builder()
+                        .cat1(cat1)
+                        .cat2(cat2)
+                        .build())
+                .map(response -> {
+                    log.info("카테고리 API 응답: {}", response);
+                    if (response.getBody() != null &&
+                        response.getBody().getItems() != null &&
+                        response.getBody().getItems().getItem() != null &&
+                        !response.getBody().getItems().getItem().isEmpty()) {
+
+                        // cat2가 있는 경우: cat2에 해당하는 항목 찾기
+                        if (cat2 != null && !cat2.trim().isEmpty()) {
+                            for (CategoryCodeResponse.Item item : response.getBody().getItems().getItem()) {
+                                if (cat2.equals(item.getCode())) {
+                                    log.info("cat2 매칭됨: code={}, name={}", item.getCode(), item.getName());
+                                    return item.getName();
+                                }
+                            }
+                        }
+
+                        // cat1만 있는 경우: cat1에 해당하는 항목 찾기
+                        if (cat1 != null && !cat1.trim().isEmpty()) {
+                            for (CategoryCodeResponse.Item item : response.getBody().getItems().getItem()) {
+                                if (cat1.equals(item.getCode())) {
+                                    log.info("cat1 매칭됨: code={}, name={}", item.getCode(), item.getName());
+                                    return item.getName();
+                                }
+                            }
+                        }
+
+                        log.warn("매칭되는 카테고리 코드 없음: cat1={}, cat2={}", cat1, cat2);
+                    }
+                    return "정보없음";
+                })
+                .onErrorReturn("정보없음");
+    }
+
+    private static class TranquilityAndThemeResult {
+        private final int tranquilityLevel;
+        private final String theme;
+
+        public TranquilityAndThemeResult(int tranquilityLevel, String theme) {
+            this.tranquilityLevel = tranquilityLevel;
+            this.theme = theme;
+        }
+
+        public int getTranquilityLevel() {
+            return tranquilityLevel;
+        }
+
+        public String getTheme() {
+            return theme;
         }
     }
 }

--- a/src/main/java/com/comma/soomteum/domain/place/service/PlaceDetailIntegratedService.java
+++ b/src/main/java/com/comma/soomteum/domain/place/service/PlaceDetailIntegratedService.java
@@ -11,6 +11,8 @@ import com.comma.soomteum.domain.place.dto.KorService2Response;
 import com.comma.soomteum.domain.place.dto.TourApiRequestDto;
 import com.comma.soomteum.domain.place.dto.response.PlaceDetailIntegratedResponseDto;
 import com.comma.soomteum.domain.place.dto.response.PlaceDetailResponseDto;
+import com.comma.soomteum.domain.theme.entity.Theme;
+import com.comma.soomteum.domain.theme.repository.ThemeRepository;
 import com.comma.soomteum.domain.tour.service.TourService;
 import com.comma.soomteum.domain.userPlace.enums.UserActionType;
 import com.comma.soomteum.domain.userPlace.service.UserPlaceService;
@@ -34,6 +36,7 @@ public class PlaceDetailIntegratedService {
     private final AiReviewService aiReviewService;
     private final AiRecommendationService aiRecommendationService;
     private final PublicParkingService publicParkingService;
+    private final ThemeRepository themeRepository;
 
     private static final String GANGNEUNG_REGION_CODE = "32230";
     private static final String GANGNEUNG_AREA_CODE = "32";
@@ -82,6 +85,7 @@ public class PlaceDetailIntegratedService {
                 .flatMap(result -> {
                     builder.tranquilityLevel(result.getTranquilityLevel());
                     builder.theme(result.getTheme());
+                    builder.themeName(result.getThemeName());
 
                     // 지역 정보 설정 및 강릉시 전용 기능 처리
                     return processRegionSpecificFeatures(builder, item, contentId);
@@ -90,7 +94,7 @@ public class PlaceDetailIntegratedService {
 
     private Mono<TranquilityAndThemeResult> getTranquilityLevelAndTheme(String contentId, String title, String longitude, String latitude) {
         if (longitude == null || latitude == null) {
-            return Mono.just(new TranquilityAndThemeResult(-1, "정보없음"));
+            return Mono.just(new TranquilityAndThemeResult(-1, "정보없음", "정보없음"));
         }
 
         try {
@@ -114,13 +118,25 @@ public class PlaceDetailIntegratedService {
                             ? item.getCat2()
                             : (item.getCat1() != null ? item.getCat1() : "정보없음");
 
-                        log.info("최종 테마 설정: {}", theme);
-                        return new TranquilityAndThemeResult(tranquilityLevel, theme);
+                        // cat2로 theme name 조회
+                        String themeName = "정보없음";
+                        if (item.getCat2() != null && !item.getCat2().trim().isEmpty()) {
+                            try {
+                                themeName = themeRepository.findByCat2(item.getCat2())
+                                    .map(Theme::getName)
+                                    .orElse("정보없음");
+                            } catch (Exception e) {
+                                log.warn("Theme 조회 실패: cat2={}", item.getCat2(), e);
+                            }
+                        }
+
+                        log.info("최종 테마 설정: theme={}, themeName={}", theme, themeName);
+                        return new TranquilityAndThemeResult(tranquilityLevel, theme, themeName);
                     })
-                    .defaultIfEmpty(new TranquilityAndThemeResult(-1, "정보없음"));
+                    .defaultIfEmpty(new TranquilityAndThemeResult(-1, "정보없음", "정보없음"));
         } catch (Exception e) {
             log.warn("한적함 등급 및 테마 정보 조회 실패: contentId={}", contentId, e);
-            return Mono.just(new TranquilityAndThemeResult(-1, "정보없음"));
+            return Mono.just(new TranquilityAndThemeResult(-1, "정보없음", "정보없음"));
         }
     }
 
@@ -330,10 +346,12 @@ public class PlaceDetailIntegratedService {
     private static class TranquilityAndThemeResult {
         private final int tranquilityLevel;
         private final String theme;
+        private final String themeName;
 
-        public TranquilityAndThemeResult(int tranquilityLevel, String theme) {
+        public TranquilityAndThemeResult(int tranquilityLevel, String theme, String themeName) {
             this.tranquilityLevel = tranquilityLevel;
             this.theme = theme;
+            this.themeName = themeName;
         }
 
         public int getTranquilityLevel() {
@@ -342,6 +360,10 @@ public class PlaceDetailIntegratedService {
 
         public String getTheme() {
             return theme;
+        }
+
+        public String getThemeName() {
+            return themeName;
         }
     }
 }

--- a/src/main/java/com/comma/soomteum/domain/theme/repository/ThemeRepository.java
+++ b/src/main/java/com/comma/soomteum/domain/theme/repository/ThemeRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface ThemeRepository extends JpaRepository<Theme, Long> {
     Optional<Theme> findByName(String name);
+    Optional<Theme> findByCat2(String cat2);
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #67 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 여행지 상세 통합 조회 API에 테마 API 연동해서 테마 정보를 불러옵니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 기존: "관광지" (하드코딩)
- 변경: 실제 카테고리 코드 (예: "A0201", "A02")
- 우선순위: 중분류(cat2) → 대분류(cat1) → "정보없음"


## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="1073" height="509" alt="image" src="https://github.com/user-attachments/assets/b4b3bfa0-8912-40ab-93db-999fac0595c7" />
<img width="1072" height="361" alt="image" src="https://github.com/user-attachments/assets/c4c789ab-04cf-42b7-b36f-cdf90a16febb" />
