### PR TITLE
[Feat/#72] 지역, 테마 전체 조회 api 추가

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/region/controller/RegionController.java
+++ b/src/main/java/com/comma/soomteum/domain/region/controller/RegionController.java
@@ -1,0 +1,29 @@
+package com.comma.soomteum.domain.region.controller;
+
+import com.comma.soomteum.domain.region.dto.RegionGroupResponseDto;
+import com.comma.soomteum.domain.region.service.RegionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Region", description = "지역 관리 API")
+@RestController
+@RequestMapping("/api/places/regions")
+@RequiredArgsConstructor
+public class RegionController {
+
+    private final RegionService regionService;
+
+    @Operation(summary = "전체 지역 목록 조회", description = "지역코드별로 그룹핑된 모든 지역 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<RegionGroupResponseDto>> getAllRegions() {
+        List<RegionGroupResponseDto> regions = regionService.getAllRegions();
+        return ResponseEntity.ok(regions);
+    }
+}

--- a/src/main/java/com/comma/soomteum/domain/region/dto/RegionGroupResponseDto.java
+++ b/src/main/java/com/comma/soomteum/domain/region/dto/RegionGroupResponseDto.java
@@ -1,0 +1,39 @@
+package com.comma.soomteum.domain.region.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "지역 그룹 응답")
+public class RegionGroupResponseDto {
+
+    @Schema(description = "지역 코드", example = "32")
+    private String areaCode;
+
+    @Schema(description = "지역명", example = "강원")
+    private String areaName;
+
+    @Schema(description = "시군구 목록")
+    private List<SigunguInfo> sigunguList;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "시군구 정보")
+    public static class SigunguInfo {
+        @Schema(description = "시군구 코드", example = "1")
+        private String sigunguCode;
+
+        @Schema(description = "시군구명", example = "강릉시")
+        private String sigunguName;
+    }
+}

--- a/src/main/java/com/comma/soomteum/domain/region/dto/RegionResponseDto.java
+++ b/src/main/java/com/comma/soomteum/domain/region/dto/RegionResponseDto.java
@@ -1,0 +1,30 @@
+package com.comma.soomteum.domain.region.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "지역 응답")
+public class RegionResponseDto {
+
+    @Schema(description = "지역 ID", example = "1")
+    private Long regionId;
+
+    @Schema(description = "지역 코드", example = "32")
+    private String areaCode;
+
+    @Schema(description = "시군구 코드", example = "1")
+    private String sigunguCode;
+
+    @Schema(description = "지역명", example = "강원")
+    private String areaName;
+
+    @Schema(description = "시군구명", example = "강릉시")
+    private String sigunguName;
+}

--- a/src/main/java/com/comma/soomteum/domain/region/service/RegionService.java
+++ b/src/main/java/com/comma/soomteum/domain/region/service/RegionService.java
@@ -1,0 +1,76 @@
+package com.comma.soomteum.domain.region.service;
+
+import com.comma.soomteum.domain.region.dto.RegionGroupResponseDto;
+import com.comma.soomteum.domain.region.entity.Region;
+import com.comma.soomteum.domain.region.repository.RegionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RegionService {
+
+    private final RegionRepository regionRepository;
+
+    public List<RegionGroupResponseDto> getAllRegions() {
+        List<Region> regions = regionRepository.findAll();
+        
+        Map<String, List<Region>> groupedByAreaCode = regions.stream()
+                .collect(Collectors.groupingBy(Region::getKorAreaCode));
+
+        return groupedByAreaCode.entrySet().stream()
+                .map(entry -> {
+                    String areaCode = entry.getKey();
+                    List<Region> areaRegions = entry.getValue();
+
+                    List<RegionGroupResponseDto.SigunguInfo> sigunguList = areaRegions.stream()
+                            .map(region -> RegionGroupResponseDto.SigunguInfo.builder()
+                                    .sigunguCode(region.getKorSigunguCode())
+                                    .sigunguName(region.getName())
+                                    .build())
+                            .collect(Collectors.toList());
+
+                    return RegionGroupResponseDto.builder()
+                            .areaCode(areaCode)
+                            .areaName(getAreaName(areaCode))
+                            .sigunguList(sigunguList)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    private String getAreaName(String areaCode) {
+        if (areaCode == null) {
+            return "정보없음";
+        }
+        
+        switch (areaCode) {
+            case "1":
+                return "서울";
+            case "2":
+                return "인천";
+            case "3":
+                return "대전";
+            case "4":
+                return "대구";
+            case "5":
+                return "광주";
+            case "6":
+                return "부산";
+            case "7":
+                return "울산";
+            case "8":
+                return "세종";
+            case "31":
+                return "경기도";
+            case "32":
+                return "강원";
+            default:
+                return "기타";
+        }
+    }
+}

--- a/src/main/java/com/comma/soomteum/domain/theme/controller/ThemeController.java
+++ b/src/main/java/com/comma/soomteum/domain/theme/controller/ThemeController.java
@@ -1,0 +1,29 @@
+package com.comma.soomteum.domain.theme.controller;
+
+import com.comma.soomteum.domain.theme.dto.ThemeGroupResponseDto;
+import com.comma.soomteum.domain.theme.service.ThemeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Theme", description = "테마 관리 API")
+@RestController
+@RequestMapping("/api/places/themes")
+@RequiredArgsConstructor
+public class ThemeController {
+
+    private final ThemeService themeService;
+
+    @Operation(summary = "전체 테마 목록 조회", description = "대분류별로 그룹핑된 모든 테마 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<ThemeGroupResponseDto>> getAllThemes() {
+        List<ThemeGroupResponseDto> themes = themeService.getAllThemes();
+        return ResponseEntity.ok(themes);
+    }
+}

--- a/src/main/java/com/comma/soomteum/domain/theme/dto/ThemeGroupResponseDto.java
+++ b/src/main/java/com/comma/soomteum/domain/theme/dto/ThemeGroupResponseDto.java
@@ -1,0 +1,39 @@
+package com.comma.soomteum.domain.theme.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "테마 그룹 응답")
+public class ThemeGroupResponseDto {
+
+    @Schema(description = "대분류 코드", example = "A01")
+    private String cat1;
+
+    @Schema(description = "대분류명", example = "자연")
+    private String cat1Name;
+
+    @Schema(description = "중분류 목록")
+    private List<Cat2Info> cat2List;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "중분류 정보")
+    public static class Cat2Info {
+        @Schema(description = "중분류 코드", example = "A0101")
+        private String cat2;
+
+        @Schema(description = "중분류명", example = "자연관광지")
+        private String cat2Name;
+    }
+}

--- a/src/main/java/com/comma/soomteum/domain/theme/dto/ThemeResponseDto.java
+++ b/src/main/java/com/comma/soomteum/domain/theme/dto/ThemeResponseDto.java
@@ -1,0 +1,30 @@
+package com.comma.soomteum.domain.theme.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "테마 응답")
+public class ThemeResponseDto {
+
+    @Schema(description = "테마 ID", example = "1")
+    private Long themeId;
+
+    @Schema(description = "대분류 코드", example = "A01")
+    private String cat1;
+
+    @Schema(description = "대분류명", example = "자연")
+    private String cat1Name;
+
+    @Schema(description = "중분류 코드", example = "A0101")
+    private String cat2;
+
+    @Schema(description = "중분류명", example = "자연관광지")
+    private String cat2Name;
+}

--- a/src/main/java/com/comma/soomteum/domain/theme/service/ThemeService.java
+++ b/src/main/java/com/comma/soomteum/domain/theme/service/ThemeService.java
@@ -1,0 +1,64 @@
+package com.comma.soomteum.domain.theme.service;
+
+import com.comma.soomteum.domain.theme.dto.ThemeGroupResponseDto;
+import com.comma.soomteum.domain.theme.entity.Theme;
+import com.comma.soomteum.domain.theme.repository.ThemeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ThemeService {
+
+    private final ThemeRepository themeRepository;
+
+    public List<ThemeGroupResponseDto> getAllThemes() {
+        List<Theme> themes = themeRepository.findAll();
+        
+        Map<String, List<Theme>> groupedByCat1 = themes.stream()
+                .collect(Collectors.groupingBy(Theme::getCat1));
+
+        return groupedByCat1.entrySet().stream()
+                .map(entry -> {
+                    String cat1 = entry.getKey();
+                    List<Theme> cat1Themes = entry.getValue();
+
+                    List<ThemeGroupResponseDto.Cat2Info> cat2List = cat1Themes.stream()
+                            .map(theme -> ThemeGroupResponseDto.Cat2Info.builder()
+                                    .cat2(theme.getCat2())
+                                    .cat2Name(theme.getName())
+                                    .build())
+                            .collect(Collectors.toList());
+
+                    return ThemeGroupResponseDto.builder()
+                            .cat1(cat1)
+                            .cat1Name(getCat1Name(cat1))
+                            .cat2List(cat2List)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    private String getCat1Name(String cat1) {
+        if (cat1 == null) {
+            return "정보없음";
+        }
+        
+        switch (cat1) {
+            case "A01":
+                return "자연";
+            case "A02":
+                return "인문";
+            case "A03":
+                return "레포츠";
+            case "A04":
+                return "쇼핑";
+            default:
+                return "기타";
+        }
+    }
+}


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #72

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
 여행지 상세 조회 API에서 테마명 표시 기능 추가 및 테마/지역 조회 API 구현

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
  1. 여행지 상세 조회 API 테마명 개선

  - PlaceDetailIntegratedResponseDto에 themeName 필드 추가
  - ThemeRepository에 findByCat2() 메서드 추가
  - PlaceDetailIntegratedService에서 cat2 코드로 Theme 엔티티 조회하여 실제 테마명 반환
  - 기존 테마 코드(A0101)와 함께 테마명(자연관광지) 모두 제공

  2. 테마 조회 API 구현

  - ThemeController, ThemeService, ThemeGroupResponseDto 생성
  - 대분류(cat1)별로 그룹핑된 테마 목록 조회 API 구현
  - cat1 코드를 한국어명으로 매핑 (A01→자연, A02→인문, A03→레포츠, A04→쇼핑)
  - API 엔드포인트: GET /api/places/themes

  3. 지역 조회 API 구현

  - RegionController, RegionService, RegionGroupResponseDto 생성
  - 지역코드(korAreaCode)별로 그룹핑된 지역 목록 조회 API 구현
  - areaCode를 지역명으로 매핑 (1→서울, 2→인천, 31→경기도, 32→강원 등)
  - API 엔드포인트: GET /api/places/regions

  4. 응답 구조 개선

  - 테마/지역 모두 계층적 구조로 응답 (상위분류 + 하위분류 리스트)
  - 코드와 한국어명을 모두 포함하여 프론트엔드에서 활용도 증대
  -
## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="1772" height="1375" alt="image" src="https://github.com/user-attachments/assets/7ac9b668-a935-4c59-ba16-e14af1a0835f" />
<img width="1774" height="1360" alt="image" src="https://github.com/user-attachments/assets/b97bf14c-d264-4770-8ff9-61293f3d004b" />
