### PR TITLE
[Feat/#73] CORS 프론트 배포 도메인 허용

### DIFF
--- a/src/main/java/com/comma/soomteum/config/CorsGlobalConfig.java
+++ b/src/main/java/com/comma/soomteum/config/CorsGlobalConfig.java
@@ -21,7 +21,7 @@ public class CorsGlobalConfig {
         // 정확 매칭 (운영/로컬)
         cfg.setAllowedOriginPatterns(Arrays.asList(
                 "https://soomteum.site",
-                "http://www.localhost:3000",
+                "https://www.soomteum.site",
                 "http://localhost:3000"
         ));
 

--- a/src/main/java/com/comma/soomteum/config/CorsGlobalConfig.java
+++ b/src/main/java/com/comma/soomteum/config/CorsGlobalConfig.java
@@ -21,6 +21,7 @@ public class CorsGlobalConfig {
         // 정확 매칭 (운영/로컬)
         cfg.setAllowedOriginPatterns(Arrays.asList(
                 "https://soomteum.site",
+                "http://www.localhost:3000",
                 "http://localhost:3000"
         ));
 


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #73 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 프론트엔드 배포 도메인에서 백엔드 API 호출 시 발생하는 CORS 문제를 방지하기 위해 CorsGlobalConfig에 프론트 배포 도메인 https://www.soomteum.site 허용합니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- CorsGlobalConfig의 setAllowedOriginPatterns에 프론트 도메인 추가
- allowCredentials(true) 사용 중이므로 * 대신 정확한 도메인 또는 패턴 사용 필요
- 변경 후 스테이징/프로덕션에서 브라우저와 curl로 CORS 헤더 정상 동작 확인
