### PR TITLE
[Feat/#76] 로그인 유저 좋아요 상태 조회 api

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceLikeController.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceLikeController.java
@@ -94,6 +94,7 @@ public class PlaceLikeController {
     })
     @GetMapping("/like/status")
     public ResponseEntity<ApiResponse<PlaceLikeStatusResponseDto>> getPlaceLikeStatus(
+            @Parameter(description = "공공데이터 API의 컨텐츠 ID", required = true, example = "128758")
             @RequestParam String contentId,
             @Parameter(hidden = true) @LoginUser User user) {
         boolean isLiked = userPlaceService.isUserActionExists(user.getUserId(), contentId, UserActionType.LIKE);

--- a/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceLikeController.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceLikeController.java
@@ -3,6 +3,7 @@ package com.comma.soomteum.domain.userPlace.controller;
 import com.comma.soomteum.domain.auth.annotation.LoginUser;
 import com.comma.soomteum.domain.user.entity.User;
 import com.comma.soomteum.domain.userPlace.dto.PlaceActionRequestDto;
+import com.comma.soomteum.domain.userPlace.dto.PlaceLikeStatusResponseDto;
 import com.comma.soomteum.domain.userPlace.dto.UserPlaceResponseDto;
 import com.comma.soomteum.domain.userPlace.enums.UserActionType;
 import com.comma.soomteum.domain.userPlace.service.UserPlaceService;
@@ -80,5 +81,23 @@ public class PlaceLikeController {
             @RequestParam String contentId) {
         long likeCount = userPlaceService.getActionCountByContentId(contentId, UserActionType.LIKE);
         return ResponseEntity.ok(ApiResponse.ok(likeCount));
+    }
+
+    @Operation(
+            summary = "장소 좋아요 상태 조회", 
+            description = "사용자가 특정 장소에 좋아요를 눌렀는지 확인합니다.",
+            security = @SecurityRequirement(name = "JWT TOKEN")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "좋아요 상태 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @GetMapping("/like/status")
+    public ResponseEntity<ApiResponse<PlaceLikeStatusResponseDto>> getPlaceLikeStatus(
+            @RequestParam String contentId,
+            @Parameter(hidden = true) @LoginUser User user) {
+        boolean isLiked = userPlaceService.isUserActionExists(user.getUserId(), contentId, UserActionType.LIKE);
+        PlaceLikeStatusResponseDto responseDto = PlaceLikeStatusResponseDto.of(isLiked, contentId);
+        return ResponseEntity.ok(ApiResponse.ok(responseDto));
     }
 }

--- a/src/main/java/com/comma/soomteum/domain/userPlace/dto/PlaceLikeStatusResponseDto.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/dto/PlaceLikeStatusResponseDto.java
@@ -1,0 +1,28 @@
+package com.comma.soomteum.domain.userPlace.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+/**
+ * 좋아요 상태 조회 응답 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(name = "PlaceLikeStatusResponse", description = "장소 좋아요 상태 조회 응답")
+public class PlaceLikeStatusResponseDto {
+
+    @Schema(description = "좋아요 여부", example = "true")
+    private boolean isLike;
+
+    @Schema(description = "콘텐츠 ID", example = "128758")
+    private String contentId;
+
+    public static PlaceLikeStatusResponseDto of(boolean isLike, String contentId) {
+        return PlaceLikeStatusResponseDto.builder()
+                .isLike(isLike)
+                .contentId(contentId)
+                .build();
+    }
+}

--- a/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
@@ -258,4 +258,16 @@ public class UserPlaceService {
                 .message(type + " " + (enable ? "ON" : "OFF"))
                 .build();
     }
+
+    @Transactional(readOnly = true)
+    public boolean isUserActionExists(Long userId, String contentId, UserActionType type) {
+        var placeOpt = placeService.findByContentId(contentId);
+        if (placeOpt.isEmpty()) {
+            return false;
+        }
+        
+        var place = placeOpt.get();
+        return userPlaceRepository.existsByUser_UserIdAndPlace_PlaceIdAndType(
+                userId, place.getPlaceId(), type);
+    }
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #76

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
  현재 로그인된 사용자가 특정 장소에 좋아요를 눌렀는지 확인할 수 있는 API를 추가했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
  - 새로운 API 엔드포인트 추가: GET /api/places/like/status
    - 파라미터: contentId (RequestParam), user (LoginUser)
    - 사용자의 특정 장소 좋아요 상태를 true/false로 반환
  - 전용 응답 DTO 생성: PlaceLikeStatusResponseDto
    - isLike: 좋아요 여부 (boolean)
    - contentId: 콘텐츠 ID (String)
  - 서비스 로직 추가: UserPlaceService.isUserActionExists()
    - contentId로 장소를 찾고 사용자의 액션 존재 여부를 확인
    - 기존 UserPlaceRepository.existsByUser_UserIdAndPlace_PlaceIdAndType 활용

## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="1783" height="1439" alt="image" src="https://github.com/user-attachments/assets/3e68a107-99e5-4cc6-9235-d5a7c599f43d" />
