### PR TITLE
[Feat/#81] 로그인된 사용자 Place 저장 유무 api

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceSaveController.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceSaveController.java
@@ -3,6 +3,7 @@ package com.comma.soomteum.domain.userPlace.controller;
 import com.comma.soomteum.domain.auth.annotation.LoginUser;
 import com.comma.soomteum.domain.user.entity.User;
 import com.comma.soomteum.domain.userPlace.dto.PlaceActionRequestDto;
+import com.comma.soomteum.domain.userPlace.dto.PlaceSaveStatusResponseDto;
 import com.comma.soomteum.domain.userPlace.dto.UserPlacePageResponseDto;
 import com.comma.soomteum.domain.userPlace.dto.UserPlaceResponseDto;
 import com.comma.soomteum.domain.userPlace.enums.UserActionType;
@@ -93,5 +94,24 @@ public class PlaceSaveController {
 
         var result = userPlaceService.getMyPlaces(user.getUserId (), UserActionType.SAVE, page, size);
         return ResponseEntity.ok(ApiResponse.ok(result));
+    }
+
+    @Operation(
+            summary = "장소 저장 상태 조회", 
+            description = "사용자가 특정 장소를 저장했는지 확인합니다.",
+            security = @SecurityRequirement(name = "JWT TOKEN")
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "저장 상태 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @GetMapping("/save/status")
+    public ResponseEntity<ApiResponse<PlaceSaveStatusResponseDto>> getPlaceSaveStatus(
+            @Parameter(description = "공공데이터 API의 컨텐츠 ID", required = true, example = "128758")
+            @RequestParam String contentId,
+            @Parameter(hidden = true) @LoginUser User user) {
+        boolean isSaved = userPlaceService.isUserActionExists(user.getUserId(), contentId, UserActionType.SAVE);
+        PlaceSaveStatusResponseDto responseDto = PlaceSaveStatusResponseDto.of(isSaved, contentId);
+        return ResponseEntity.ok(ApiResponse.ok(responseDto));
     }
 }

--- a/src/main/java/com/comma/soomteum/domain/userPlace/dto/PlaceSaveStatusResponseDto.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/dto/PlaceSaveStatusResponseDto.java
@@ -1,0 +1,28 @@
+package com.comma.soomteum.domain.userPlace.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+/**
+ * 저장 상태 조회 응답 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(name = "PlaceSaveStatusResponse", description = "장소 저장 상태 조회 응답")
+public class PlaceSaveStatusResponseDto {
+
+    @Schema(description = "저장 여부", example = "true")
+    private boolean isSave;
+
+    @Schema(description = "콘텐츠 ID", example = "128758")
+    private String contentId;
+
+    public static PlaceSaveStatusResponseDto of(boolean isSave, String contentId) {
+        return PlaceSaveStatusResponseDto.builder()
+                .isSave(isSave)
+                .contentId(contentId)
+                .build();
+    }
+}


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #81

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
장소 저장 상태 조회 API 추가

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
  - PlaceSaveStatusResponseDto 클래스 생성
  - PlaceSaveController에 getPlaceSaveStatus 메서드 추가
  - 사용자가 특정 장소를 저장했는지 확인하는
  /api/my/places/save/status 엔드포인트 구현
  - PlaceLikeController의 getPlaceLikeStatus와 동일한 패턴으로
   일관성 유지

## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="1769" height="1191" alt="image" src="https://github.com/user-attachments/assets/2d1e9ecd-62f5-4745-8d67-e84b51f4c688" />
