### PR TITLE
[fix/#84] 장소 저장/좋아요 로직 개편

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceSaveController.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceSaveController.java
@@ -69,11 +69,10 @@ public class PlaceSaveController {
     @DeleteMapping("/save")
     public ResponseEntity<ApiResponse<UserPlaceResponseDto>> unsave(
             @Parameter(hidden = true) @LoginUser User user,
-            @Parameter(description = "공공데이터 API의 콘텐츠 ID", required = true, example = "128758")
-            @RequestParam String contentId) {
+            @Valid @RequestBody PlaceActionRequestDto request) {
 
         var dto = userPlaceService.removeSaveByContentId(
-                user.getUserId(), contentId);
+                user.getUserId(), request.getContentId());
         return ResponseEntity.ok(ApiResponse.ok(dto));
     }
 

--- a/src/main/java/com/comma/soomteum/domain/userPlace/dto/PlaceActionRequestDto.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/dto/PlaceActionRequestDto.java
@@ -16,7 +16,7 @@ import java.math.BigDecimal;
 public class PlaceActionRequestDto {
 
     @NotBlank
-    @Schema(description = "공공데이터 API의 컨텐츠 ID", example = "123456")
+    @Schema(description = "공공데이터 API의 컨텐츠 ID", example = "128758")
     private String contentId;
 
     @NotBlank
@@ -24,7 +24,7 @@ public class PlaceActionRequestDto {
     private String regionName;
 
     @NotBlank
-    @Schema(description = "테마명", example = "자연")
+    @Schema(description = "테마명", example = "자연관광지")
     private String themeName;
 
     @NotNull

--- a/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
@@ -212,10 +212,6 @@ public class UserPlaceService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         
         var place = placeService.findOrCreatePlace(contentId, regionName, themeName, cnctrLevel);
-        
-        if (place.getPlaceId() == null) {
-            throw new CustomException(ErrorCode.PLACE_NOT_FOUND);
-        }
 
         boolean changed = false;
 


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #84

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
장소 저장 상태 조회 API 추가 및 Place 생성 로직 개선

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
 - PlaceSaveStatusResponseDto 클래스 생성
  - PlaceSaveController에 getPlaceSaveStatus 메서드 추가 (PlaceLikeController의 getPlaceLikeStatus와 동일한 패턴)
  - PlaceSaveController의 unsave 메서드를 PlaceActionRequestDto 사용하도록 수정
  - UserPlaceService의 setActionByContentId에서 Place 생성 실패 시 정확한 에러 메시지 반환하도록 개선 (REGION_NOT_FOUND, THEME_NOT_FOUND 등)
  - 
## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
