### PR TITLE
[Fix/#90] 내 저장 목록 조회 API에 여행지 이름 필드 추가

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/place/entity/Place.java
+++ b/src/main/java/com/comma/soomteum/domain/place/entity/Place.java
@@ -23,6 +23,9 @@ public class Place extends BaseEntity {
     @Column(length = 255, nullable = false)
     private String contentId;
 
+    @Column(length = 255)
+    private String name;
+
     @Column(length = 100, nullable = false)
     @Builder.Default
     private BigDecimal cnctrLevel = BigDecimal.ZERO;

--- a/src/main/java/com/comma/soomteum/domain/place/service/PlaceService.java
+++ b/src/main/java/com/comma/soomteum/domain/place/service/PlaceService.java
@@ -88,12 +88,12 @@ public class PlaceService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public Place findOrCreatePlace(String contentId, String regionName, String themeName, BigDecimal cnctrLevel) {
+    public Place findOrCreatePlace(String contentId, String regionName, String themeName, String placeName, BigDecimal cnctrLevel) {
         return placeRepository.findByContentId(contentId)
-                .orElseGet(() -> createPlace(contentId, regionName, themeName, cnctrLevel));
+                .orElseGet(() -> createPlace(contentId, regionName, themeName, placeName, cnctrLevel));
     }
 
-    private Place createPlace(String contentId, String regionName, String themeName, BigDecimal cnctrLevel) {
+    private Place createPlace(String contentId, String regionName, String themeName, String placeName, BigDecimal cnctrLevel) {
         // Region 찾기 - 없으면 기본값 사용
         var region = regionRepository.findByName(regionName)
                 .orElse(regionRepository.findByName("강릉시")
@@ -108,6 +108,7 @@ public class PlaceService {
 
         var place = Place.builder()
                 .contentId(contentId)
+                .name(placeName)
                 .cnctrLevel(cnctrLevel)
                 .likeCount(0L)
                 .region(region)

--- a/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceLikeController.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceLikeController.java
@@ -42,11 +42,12 @@ public class PlaceLikeController {
             @Valid @RequestBody PlaceActionRequestDto request) {
         UserPlaceResponseDto responseDto = userPlaceService.setActionByContentId(
                 user.getUserId(),
-                request.getContentId(), 
-                request.getRegionName(), 
-                request.getThemeName(), 
+                request.getContentId(),
+                request.getRegionName(),
+                request.getThemeName(),
+                request.getPlaceName(),
                 request.getCnctrLevel(),
-                UserActionType.LIKE, 
+                UserActionType.LIKE,
                 true);
         return ResponseEntity.ok(ApiResponse.ok(responseDto));
     }

--- a/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceSaveController.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceSaveController.java
@@ -47,11 +47,12 @@ public class PlaceSaveController {
 
         var dto = userPlaceService.setActionByContentId(
                 user.getUserId(),
-                request.getContentId(), 
-                request.getRegionName(), 
-                request.getThemeName(), 
+                request.getContentId(),
+                request.getRegionName(),
+                request.getThemeName(),
+                request.getPlaceName(),
                 request.getCnctrLevel(),
-                UserActionType.SAVE, 
+                UserActionType.SAVE,
                 true);
         return ResponseEntity.ok(ApiResponse.ok(dto));
     }

--- a/src/main/java/com/comma/soomteum/domain/userPlace/dto/PlaceActionRequestDto.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/dto/PlaceActionRequestDto.java
@@ -27,6 +27,9 @@ public class PlaceActionRequestDto {
     @Schema(description = "테마명", example = "자연관광지")
     private String themeName;
 
+    @Schema(description = "여행지 이름", example = "경복궁")
+    private String placeName;
+
     @NotNull
     @Schema(description = "혼잡도 레벨", example = "3.5")
     private BigDecimal cnctrLevel;

--- a/src/main/java/com/comma/soomteum/domain/userPlace/dto/UserPlaceItemDto.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/dto/UserPlaceItemDto.java
@@ -22,6 +22,9 @@ public class UserPlaceItemDto {
     @Schema(description = "Place 콘텐츠 ID", example = "content123")
     private String contentId;
 
+    @Schema(description = "여행지 이름", example = "경복궁")
+    private String placeName;
+
     @Schema(description = "Place 좋아요 수", example = "42")
     private Long likeCount;
 

--- a/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
@@ -173,6 +173,7 @@ public class UserPlaceService {
             return UserPlaceItemDto.builder()
                     .cnctrLevel(place.getCnctrLevel())
                     .contentId(place.getContentId())
+                    .placeName(place.getName())
                     .likeCount(place.getLikeCount())
                     .themeName(place.getTheme() != null ? place.getTheme().getName() : null)
                     .savedAt(up.getCreatedAt())
@@ -203,7 +204,7 @@ public class UserPlaceService {
     }
 
     @Transactional
-    public UserPlaceResponseDto setActionByContentId(Long userId, String contentId, String regionName, String themeName, BigDecimal cnctrLevel, UserActionType type, boolean enable) {
+    public UserPlaceResponseDto setActionByContentId(Long userId, String contentId, String regionName, String themeName, String placeName, BigDecimal cnctrLevel, UserActionType type, boolean enable) {
         if (userId == null) {
             throw new CustomException(ErrorCode.USER_NOT_FOUND);
         }
@@ -211,7 +212,7 @@ public class UserPlaceService {
         var user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         
-        var place = placeService.findOrCreatePlace(contentId, regionName, themeName, cnctrLevel);
+        var place = placeService.findOrCreatePlace(contentId, regionName, themeName, placeName, cnctrLevel);
 
         boolean changed = false;
 


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #90 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 내 저장 목록 조회 API에서 여행지 이름(placeName)이 누락되어 프론트에서 목록에 이름이 표시되지 않음
- 저장/조회 API 모두에 placeName 필드를 반영

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 엔티티
  - Place 엔티티에 name 컬럼 추가
- DTO
  - PlaceActionRequestDto, UserPlaceItemDto에 placeName 필드 추가
- API
  - 저장 API (PlaceSaveController) 수정: placeName 처리
  - 좋아요 API (PlaceLikeController) 수정: placeName 반영
- 서비스
  - UserPlaceService.setActionByContentId 수정
  - PlaceService.findOrCreatePlace / createPlace 수정
  - 조회 API에서 placeName 반환 추가
- DB
  - RDS place 테이블에 name 컬럼 추가 (ALTER TABLE)

## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="398" height="323" alt="image" src="https://github.com/user-attachments/assets/086db9e9-f1ba-423f-8d68-cdf489bb2759" />

<img width="475" height="202" alt="image" src="https://github.com/user-attachments/assets/9aa110e3-fee9-4f16-ae03-63065aec30fa" />
