### PR TITLE
[Fix/#91] 좋아요 저장 동시 트랜잭션 문제

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/userPlace/dto/PlaceActionRequestDto.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/dto/PlaceActionRequestDto.java
@@ -20,7 +20,7 @@ public class PlaceActionRequestDto {
     private String contentId;
 
     @NotBlank
-    @Schema(description = "지역명", example = "서울")
+    @Schema(description = "지역명", example = "강릉시")
     private String regionName;
 
     @NotBlank

--- a/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
@@ -213,34 +213,50 @@ public class UserPlaceService {
         
         var place = placeService.findOrCreatePlace(contentId, regionName, themeName, cnctrLevel);
 
+        // 유저별 동기화로 동시성 문제 해결
+        synchronized (userId.toString().intern()) {
+            return performUserPlaceAction(user, place, type, enable);
+        }
+    }
+
+    private UserPlaceResponseDto performUserPlaceAction(com.comma.soomteum.domain.user.entity.User user, com.comma.soomteum.domain.place.entity.Place place, UserActionType type, boolean enable) {
         boolean changed = false;
 
         if (enable) {
             // 이미 존재하는지 확인
-            boolean exists = userPlaceRepository.existsByUser_UserIdAndPlace_PlaceIdAndType(userId, place.getPlaceId(), type);
-            if (!exists) {
+            var existing = userPlaceRepository.findByUser_UserIdAndPlace_PlaceIdAndType(user.getUserId(), place.getPlaceId(), type);
+            if (existing.isEmpty()) {
                 try {
-                    userPlaceRepository.save(UserPlace.builder()
+                    var newUserPlace = UserPlace.builder()
                             .user(user)
                             .place(place)
                             .type(type)
-                            .build());
+                            .build();
+                    userPlaceRepository.save(newUserPlace);
+                    userPlaceRepository.flush(); // 즉시 DB에 반영
+                    
                     if (type == UserActionType.LIKE) {
                         place.increaseLikeCount();
                         placeRepository.save(place);
+                        placeRepository.flush();
                     }
                     changed = true;
                 } catch (org.springframework.dao.DataIntegrityViolationException e) {
-                    // 동시성 문제로 중복 생성 시도 - 무시
+                    // 중복 키 제약조건 위반 시 이미 존재하는 것으로 간주
+                    // 로그를 남기고 정상 처리
+                    System.out.println("Duplicate key constraint violation for user: " + user.getUserId() + ", place: " + place.getPlaceId() + ", type: " + type);
                 }
             }
         } else {
-            var existing = userPlaceRepository.findByUser_UserIdAndPlace_PlaceIdAndType(userId, place.getPlaceId(), type);
+            var existing = userPlaceRepository.findByUser_UserIdAndPlace_PlaceIdAndType(user.getUserId(), place.getPlaceId(), type);
             if (existing.isPresent()) {
                 userPlaceRepository.delete(existing.get());
+                userPlaceRepository.flush(); // 즉시 DB에 반영
+                
                 if (type == UserActionType.LIKE) {
                     place.decreaseLikeCount();
                     placeRepository.save(place);
+                    placeRepository.flush();
                 }
                 changed = true;
             }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #91

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
  사용자가 같은 장소에 좋아요와 저장을 동시에 요청할 때 발생하는 트랜잭션 롤백 오류를 해결했습니다. 유저별 동기화와 즉시 DB 반영을 통해 동시성 문제를 근본적으로 해결하였습니다.
## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
  - 동시성 문제 해결: synchronized (userId.toString().intern())를 사용하여 같은 사용자의 좋아요/저장 요청을 순차 처리하도록 개선
  - 즉시 DB 반영: flush() 메서드 추가로 트랜잭션 내에서 변경사항을 즉시 데이터베이스에 반영
  - 코드 리팩토링: setActionByContentId 메서드를 performUserPlaceAction으로 분리하여 가독성 향상
  - 예외 처리 개선: DataIntegrityViolationException 발생 시 로깅 추가 및 정상 처리 로직 구현
  - 스키마 예시 수정: PlaceActionRequestDto의 지역명 예시를 "서울"에서 "강릉시"로 변경


## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="799" height="222" alt="image" src="https://github.com/user-attachments/assets/9f4982d1-af1d-4f6c-9e66-6092f5977f50" />
<img width="379" height="266" alt="image" src="https://github.com/user-attachments/assets/6187a4e0-e5d8-4020-ae25-3789c16bd536" />
