### PR TITLE
[Fix/#96] 지역 코드 매칭 로직 개선

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/place/service/TatsCnctrService.java
+++ b/src/main/java/com/comma/soomteum/domain/place/service/TatsCnctrService.java
@@ -73,30 +73,7 @@ public class TatsCnctrService {
                                         return regionByArea.get();
                                     }
 
-                                    // 3. 코드 변환 시도 (예: "32" -> "1", "01" -> "1" 등)
-                                    String normalizedAreaCode = normalizeAreaCode(areaCode);
-                                    String normalizedSigunguCode = normalizeSigunguCode(sigunguCode);
-
-                                    if (!areaCode.equals(normalizedAreaCode) || !sigunguCode.equals(normalizedSigunguCode)) {
-                                        log.info("[TatsCnctr] 코드 정규화 시도: {}→{}, {}→{}",
-                                                areaCode, normalizedAreaCode, sigunguCode, normalizedSigunguCode);
-
-                                        var normalizedRegion = regionRepository.findByKorAreaCodeAndKorSigunguCode(
-                                                normalizedAreaCode, normalizedSigunguCode);
-                                        if (normalizedRegion.isPresent()) {
-                                            log.info("[TatsCnctr] 정규화 코드로 지역 찾음: {}", normalizedRegion.get().getName());
-                                            return normalizedRegion.get();
-                                        }
-
-                                        // area 코드만으로도 시도
-                                        var normalizedRegionByArea = regionRepository.findByKorAreaCode(normalizedAreaCode);
-                                        if (normalizedRegionByArea.isPresent()) {
-                                            log.info("[TatsCnctr] 정규화 area 코드로 지역 찾음: {}", normalizedRegionByArea.get().getName());
-                                            return normalizedRegionByArea.get();
-                                        }
-                                    }
-
-                                    // 4. 모든 시도 실패
+                                    // 3. 모든 시도 실패
                                     log.error("[TatsCnctr] 지역 코드 조회 완전 실패: area={}, sigungu={}",
                                             areaCode, sigunguCode);
                                     throw new CustomException(ErrorCode.REGION_NOT_FOUND);
@@ -205,31 +182,4 @@ public class TatsCnctrService {
         if (value != null && !value.isBlank()) b.queryParam(name, value);
     }
 
-    /**
-     * 지역 코드를 정규화합니다.
-     * 예: "32" -> "1", "01" -> "1"
-     */
-    private String normalizeAreaCode(String areaCode) {
-        if (areaCode == null) return null;
-
-        // 서울: 1
-        if ("01".equals(areaCode)) return "1";
-        // 인천: 2 (실제 매핑은 데이터에 따라 조정 필요)
-        if ("02".equals(areaCode)) return "2";
-        // 강원: 32 -> 1 (예시, 실제 데이터에 맞게 조정)
-        if ("32".equals(areaCode)) return "1";
-
-        // 기본적으로 앞의 0을 제거하고 반환
-        return areaCode.replaceFirst("^0+", "");
-    }
-
-    /**
-     * 시군구 코드를 정규화합니다.
-     */
-    private String normalizeSigunguCode(String sigunguCode) {
-        if (sigunguCode == null) return null;
-
-        // 기본적으로 앞의 0을 제거하고 반환
-        return sigunguCode.replaceFirst("^0+", "");
-    }
 }

--- a/src/main/java/com/comma/soomteum/domain/place/service/TatsCnctrService.java
+++ b/src/main/java/com/comma/soomteum/domain/place/service/TatsCnctrService.java
@@ -50,15 +50,57 @@ public class TatsCnctrService {
                     log.info("[TatsCnctr] 혼잡도 조회 시작: title='{}', area={}, sigungu={}",
                             req.getTitle(), req.getAreacode(), req.getSigungucode());
 
-                    return Mono.fromCallable(() ->
-                                    regionRepository.findByKorAreaCodeAndKorSigunguCode(
-                                                    req.getAreacode(), req.getSigungucode())
-                                            .orElseThrow(() -> {
-                                                log.error("[TatsCnctr] 지역 코드 조회 실패: area={}, sigungu={}",
-                                                        req.getAreacode(), req.getSigungucode());
-                                                return new CustomException(ErrorCode.REGION_NOT_FOUND);
-                                            })
-                            )
+                    return Mono.fromCallable(() -> {
+                                    String areaCode = req.getAreacode();
+                                    String sigunguCode = req.getSigungucode();
+
+                                    log.debug("[TatsCnctr] 입력 코드: areacode='{}', sigungucode='{}'", areaCode, sigunguCode);
+
+                                    // 1. 먼저 정확한 area/sigungu 코드로 조회
+                                    var region = regionRepository.findByKorAreaCodeAndKorSigunguCode(areaCode, sigunguCode);
+                                    if (region.isPresent()) {
+                                        log.debug("[TatsCnctr] 정확한 매칭 성공: {}", region.get().getName());
+                                        return region.get();
+                                    }
+
+                                    // 2. area 코드만으로 조회 시도
+                                    log.warn("[TatsCnctr] 정확한 지역 코드 매칭 실패, area 코드만으로 재시도: area={}, sigungu={}",
+                                            areaCode, sigunguCode);
+
+                                    var regionByArea = regionRepository.findByKorAreaCode(areaCode);
+                                    if (regionByArea.isPresent()) {
+                                        log.info("[TatsCnctr] area 코드로 지역 찾음: {}", regionByArea.get().getName());
+                                        return regionByArea.get();
+                                    }
+
+                                    // 3. 코드 변환 시도 (예: "32" -> "1", "01" -> "1" 등)
+                                    String normalizedAreaCode = normalizeAreaCode(areaCode);
+                                    String normalizedSigunguCode = normalizeSigunguCode(sigunguCode);
+
+                                    if (!areaCode.equals(normalizedAreaCode) || !sigunguCode.equals(normalizedSigunguCode)) {
+                                        log.info("[TatsCnctr] 코드 정규화 시도: {}→{}, {}→{}",
+                                                areaCode, normalizedAreaCode, sigunguCode, normalizedSigunguCode);
+
+                                        var normalizedRegion = regionRepository.findByKorAreaCodeAndKorSigunguCode(
+                                                normalizedAreaCode, normalizedSigunguCode);
+                                        if (normalizedRegion.isPresent()) {
+                                            log.info("[TatsCnctr] 정규화 코드로 지역 찾음: {}", normalizedRegion.get().getName());
+                                            return normalizedRegion.get();
+                                        }
+
+                                        // area 코드만으로도 시도
+                                        var normalizedRegionByArea = regionRepository.findByKorAreaCode(normalizedAreaCode);
+                                        if (normalizedRegionByArea.isPresent()) {
+                                            log.info("[TatsCnctr] 정규화 area 코드로 지역 찾음: {}", normalizedRegionByArea.get().getName());
+                                            return normalizedRegionByArea.get();
+                                        }
+                                    }
+
+                                    // 4. 모든 시도 실패
+                                    log.error("[TatsCnctr] 지역 코드 조회 완전 실패: area={}, sigungu={}",
+                                            areaCode, sigunguCode);
+                                    throw new CustomException(ErrorCode.REGION_NOT_FOUND);
+                            })
                             .subscribeOn(Schedulers.boundedElastic())
 
                             .flatMap(region -> {
@@ -161,5 +203,33 @@ public class TatsCnctrService {
 
     private static void qpIfPresent(UriBuilder b, String name, String value) {
         if (value != null && !value.isBlank()) b.queryParam(name, value);
+    }
+
+    /**
+     * 지역 코드를 정규화합니다.
+     * 예: "32" -> "1", "01" -> "1"
+     */
+    private String normalizeAreaCode(String areaCode) {
+        if (areaCode == null) return null;
+
+        // 서울: 1
+        if ("01".equals(areaCode)) return "1";
+        // 인천: 2 (실제 매핑은 데이터에 따라 조정 필요)
+        if ("02".equals(areaCode)) return "2";
+        // 강원: 32 -> 1 (예시, 실제 데이터에 맞게 조정)
+        if ("32".equals(areaCode)) return "1";
+
+        // 기본적으로 앞의 0을 제거하고 반환
+        return areaCode.replaceFirst("^0+", "");
+    }
+
+    /**
+     * 시군구 코드를 정규화합니다.
+     */
+    private String normalizeSigunguCode(String sigunguCode) {
+        if (sigunguCode == null) return null;
+
+        // 기본적으로 앞의 0을 제거하고 반환
+        return sigunguCode.replaceFirst("^0+", "");
     }
 }

--- a/src/main/java/com/comma/soomteum/domain/region/repository/RegionRepository.java
+++ b/src/main/java/com/comma/soomteum/domain/region/repository/RegionRepository.java
@@ -9,6 +9,9 @@ import java.util.Optional;
 public interface RegionRepository extends JpaRepository<Region, Long> {
     @EntityGraph(attributePaths = "cnctrSigungus")
     Optional<Region> findByKorAreaCodeAndKorSigunguCode(String korAreaCode, String korSigunguCode);
-    
+
+    @EntityGraph(attributePaths = "cnctrSigungus")
+    Optional<Region> findByKorAreaCode(String korAreaCode);
+
     Optional<Region> findByName(String name);
 }


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #96 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 지역 코드 매칭 불일치 문제를 해결하기 위해 매칭 로직을 단계적으로 개선함
- 이를 통해 REGION_NOT_FOUND 예외 대신 정상적으로 혼잡도 데이터를 반환할 수 있습니다.
## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
1. 정확한 area/sigungu 코드 조합으로 조회
2. 실패시 area 코드만으로 fallback 조회
3. 둘 다 실패하면 예외 발생


## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
