### PR TITLE
[Fix/#96] 한적함 API 지역 매핑 에러 수정

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/place/dto/KorService2Response.java
+++ b/src/main/java/com/comma/soomteum/domain/place/dto/KorService2Response.java
@@ -54,8 +54,10 @@ public class KorService2Response {
         private String cat2;
         private String firstimage;
         private String dist;
-        private String areacode;
-        private String sigungucode;
+        @JacksonXmlProperty(localName = "areacode")
+        private String areaCode;
+        @JacksonXmlProperty(localName = "sigungucode")
+        private String sigunguCode;
         private Integer pageNo;
         private Integer numOfRows;
     }

--- a/src/main/java/com/comma/soomteum/domain/place/service/TatsCnctrService.java
+++ b/src/main/java/com/comma/soomteum/domain/place/service/TatsCnctrService.java
@@ -41,18 +41,18 @@ public class TatsCnctrService {
 
     @Cacheable(
             cacheNames = "tatsCnctr",
-            key = "T(java.util.Objects).hash(#req.getAreacode(), #req.getSigungucode(), #req.getTitle(), #req.getPageNo(), #req.getNumOfRows())"
+            key = "T(java.util.Objects).hash(#req.getAreaCode(), #req.getSigunguCode(), #req.getTitle(), #req.getPageNo(), #req.getNumOfRows())"
     )
     public Mono<TatsCnctrResponse.TatsCnctrResponseDto> getCnctrRate(
             KorService2Response.LocationBasedListResponseDto req) {
 
         return Mono.defer(() -> {
                     log.info("[TatsCnctr] 혼잡도 조회 시작: title='{}', area={}, sigungu={}",
-                            req.getTitle(), req.getAreacode(), req.getSigungucode());
+                            req.getTitle(), req.getAreaCode(), req.getSigunguCode());
 
                     return Mono.fromCallable(() -> {
-                                    String areaCode = req.getAreacode();
-                                    String sigunguCode = req.getSigungucode();
+                                    String areaCode = req.getAreaCode();
+                                    String sigunguCode = req.getSigunguCode();
 
                                     log.debug("[TatsCnctr] 입력 코드: areacode='{}', sigungucode='{}'", areaCode, sigunguCode);
 


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #96 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 지역 매핑 에러 수정 및 DTO/서비스 코드 카멜케이스 정리

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- DTO 필드명 수정
  - KorService2Response.LocationBasedListResponseDto
  - areacode → areaCode
  - sigungucode → sigunguCode
  - XML 매핑을 위해 @JacksonXmlProperty 추가
- 서비스 코드 수정
  - TatsCnctrService에서 모든 getter 호출을 카멜케이스 메서드명으로 변경
  - req.getAreacode() → req.getAreaCode()
  - req.getSigungucode() → req.getSigunguCode()
- 결과
  - API 입력 파라미터 areaCode / sigunguCode가 DB 컬럼 kor_area_code / kor_sigungu_code와 올바르게 매핑되어 지역 조회 오류가 해결됨

## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
