### PR TITLE
[Feat/#100] 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/auth/service/AuthService.java
+++ b/src/main/java/com/comma/soomteum/domain/auth/service/AuthService.java
@@ -37,13 +37,12 @@ public class AuthService {
                                 .providerId(providerId)
                                 .nickname("유저" + providerId)
                                 .email(email)
-                                .isActive(true)
                                 .build()
                 ));
 
         // 탈퇴한 회원이 다시 로그인하는 경우 계정 복구
         boolean isReturningUser = false;
-        if (user.getIsActive() == null) {
+        if (user.isWithdrawn()) {
             user.reactivate();
             isReturningUser = true;
         }

--- a/src/main/java/com/comma/soomteum/domain/auth/service/AuthService.java
+++ b/src/main/java/com/comma/soomteum/domain/auth/service/AuthService.java
@@ -41,7 +41,14 @@ public class AuthService {
                                 .build()
                 ));
 
-        boolean isNewUser = user.getCreatedAt() != null &&
+        // 탈퇴한 회원이 다시 로그인하는 경우 계정 복구
+        boolean isReturningUser = false;
+        if (user.getIsActive() == null) {
+            user.reactivate();
+            isReturningUser = true;
+        }
+
+        boolean isNewUser = !isReturningUser && user.getCreatedAt() != null &&
                 user.getUpdatedAt() != null &&
                 user.getCreatedAt().equals(user.getUpdatedAt());
 

--- a/src/main/java/com/comma/soomteum/domain/token/repository/TokenRepository.java
+++ b/src/main/java/com/comma/soomteum/domain/token/repository/TokenRepository.java
@@ -1,6 +1,7 @@
 package com.comma.soomteum.domain.token.repository;
 
 import com.comma.soomteum.domain.token.entity.Token;
+import com.comma.soomteum.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +9,5 @@ import java.util.Optional;
 
 public interface TokenRepository extends JpaRepository<Token, Long>  {
     Optional<Token> findByRefreshToken(String refreshToken);
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/comma/soomteum/domain/user/controller/UserController.java
+++ b/src/main/java/com/comma/soomteum/domain/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.comma.soomteum.domain.auth.annotation.LoginUser;
 import com.comma.soomteum.domain.user.entity.User;
 import com.comma.soomteum.domain.user.dto.UserNicknameRequestDto;
 import com.comma.soomteum.domain.user.dto.UserProfileResponseDto;
+import com.comma.soomteum.domain.user.dto.UserWithdrawResponseDto;
 import com.comma.soomteum.domain.user.service.UserService;
 import com.comma.soomteum.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,5 +35,11 @@ public class UserController {
     @PatchMapping("/nickname")
     public ApiResponse<UserProfileResponseDto> updateNickname(@Parameter(hidden = true) @LoginUser User user, @Valid @RequestBody UserNicknameRequestDto userNicknameRequestDto) {
         return ApiResponse.ok(userService.updateNickname(user.getUserId(), userNicknameRequestDto));
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "사용자의 계정을 탈퇴 처리합니다.")
+    @DeleteMapping("/withdraw")
+    public ApiResponse<UserWithdrawResponseDto> withdrawUser(@Parameter(hidden = true) @LoginUser User user) {
+        return ApiResponse.ok(userService.withdrawUser(user.getUserId()));
     }
 }

--- a/src/main/java/com/comma/soomteum/domain/user/controller/UserController.java
+++ b/src/main/java/com/comma/soomteum/domain/user/controller/UserController.java
@@ -38,7 +38,7 @@ public class UserController {
     }
 
     @Operation(summary = "회원 탈퇴", description = "사용자의 계정을 탈퇴 처리합니다.")
-    @DeleteMapping("/withdraw")
+    @PatchMapping("/withdraw")
     public ApiResponse<UserWithdrawResponseDto> withdrawUser(@Parameter(hidden = true) @LoginUser User user) {
         return ApiResponse.ok(userService.withdrawUser(user.getUserId()));
     }

--- a/src/main/java/com/comma/soomteum/domain/user/dto/UserWithdrawResponseDto.java
+++ b/src/main/java/com/comma/soomteum/domain/user/dto/UserWithdrawResponseDto.java
@@ -1,0 +1,21 @@
+package com.comma.soomteum.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserWithdrawResponseDto {
+
+    private String message;
+
+    public static UserWithdrawResponseDto of() {
+        return UserWithdrawResponseDto.builder()
+                .message("회원 탈퇴가 완료되었습니다.")
+                .build();
+    }
+}

--- a/src/main/java/com/comma/soomteum/domain/user/entity/User.java
+++ b/src/main/java/com/comma/soomteum/domain/user/entity/User.java
@@ -29,4 +29,8 @@ public class User extends BaseEntity {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    public void withdraw() {
+        this.isActive = null;
+    }
 }

--- a/src/main/java/com/comma/soomteum/domain/user/entity/User.java
+++ b/src/main/java/com/comma/soomteum/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.comma.soomteum.domain.user.entity;
 
 import com.comma.soomteum.domain.BaseEntity;
+import com.comma.soomteum.domain.user.enums.UserStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -24,17 +25,27 @@ public class User extends BaseEntity {
 
     private String email;
 
-    private Boolean isActive;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status = UserStatus.ACTIVE;
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
 
     public void withdraw() {
-        this.isActive = null;
+        this.status = UserStatus.WITHDRAWN;
     }
 
     public void reactivate() {
-        this.isActive = true;
+        this.status = UserStatus.ACTIVE;
+    }
+
+    public boolean isWithdrawn() {
+        return this.status == UserStatus.WITHDRAWN;
+    }
+
+    public boolean isActive() {
+        return this.status == UserStatus.ACTIVE;
     }
 }

--- a/src/main/java/com/comma/soomteum/domain/user/entity/User.java
+++ b/src/main/java/com/comma/soomteum/domain/user/entity/User.java
@@ -33,4 +33,8 @@ public class User extends BaseEntity {
     public void withdraw() {
         this.isActive = null;
     }
+
+    public void reactivate() {
+        this.isActive = true;
+    }
 }

--- a/src/main/java/com/comma/soomteum/domain/user/enums/UserStatus.java
+++ b/src/main/java/com/comma/soomteum/domain/user/enums/UserStatus.java
@@ -1,0 +1,6 @@
+package com.comma.soomteum.domain.user.enums;
+
+public enum UserStatus {
+    ACTIVE,     // 활성 회원
+    WITHDRAWN   // 탈퇴 회원
+}

--- a/src/main/java/com/comma/soomteum/domain/user/service/UserService.java
+++ b/src/main/java/com/comma/soomteum/domain/user/service/UserService.java
@@ -49,7 +49,7 @@ public class UserService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 이미 탈퇴한 회원인지 확인
-        if (user.getIsActive() == null) {
+        if (user.isWithdrawn()) {
             throw new CustomException(ErrorCode.ALREADY_WITHDRAWN_USER);
         }
 

--- a/src/main/java/com/comma/soomteum/domain/user/service/UserService.java
+++ b/src/main/java/com/comma/soomteum/domain/user/service/UserService.java
@@ -1,7 +1,9 @@
 package com.comma.soomteum.domain.user.service;
 
+import com.comma.soomteum.domain.token.repository.TokenRepository;
 import com.comma.soomteum.domain.user.dto.UserNicknameRequestDto;
 import com.comma.soomteum.domain.user.dto.UserProfileResponseDto;
+import com.comma.soomteum.domain.user.dto.UserWithdrawResponseDto;
 import com.comma.soomteum.domain.user.entity.User;
 import com.comma.soomteum.domain.user.repository.UserRepository;
 import com.comma.soomteum.global.response.CustomException;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final TokenRepository tokenRepository;
 
     /**
      * 마이페이지 - 이메일, 닉네임 조회
@@ -35,5 +38,27 @@ public class UserService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         user.updateNickname(userNicknameRequestDto.getNickname());
         return UserProfileResponseDto.fromEntity(user);
+    }
+
+    /**
+     * 회원 탈퇴
+     **/
+    @Transactional
+    public UserWithdrawResponseDto withdrawUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 이미 탈퇴한 회원인지 확인
+        if (user.getIsActive() == null) {
+            throw new CustomException(ErrorCode.ALREADY_WITHDRAWN_USER);
+        }
+
+        // 해당 사용자의 모든 토큰 삭제
+        tokenRepository.deleteByUser(user);
+
+        // 회원 상태를 탈퇴로 변경 (isActive = null)
+        user.withdraw();
+
+        return UserWithdrawResponseDto.of();
     }
 }

--- a/src/main/java/com/comma/soomteum/global/response/ErrorCode.java
+++ b/src/main/java/com/comma/soomteum/global/response/ErrorCode.java
@@ -63,6 +63,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(409_001, HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     ALREADY_LIKED_PLACE(409_002, HttpStatus.CONFLICT, "이미 좋아요를 누른 장소입니다."),
     NOT_LIKED_PLACE(409_003, HttpStatus.CONFLICT, "좋아요를 누르지 않은 장소입니다."),
+    ALREADY_WITHDRAWN_USER(409_004, HttpStatus.CONFLICT, "이미 탈퇴한 회원입니다."),
 
 
     // ========================


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #100 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 사용자가 계정을 탈퇴할 수 있는 API를 구현
- isActive = null로 설정하여 탈퇴 상태를 관리하며, 연관된 JWT 토큰을 완전히 삭제하여 보안 강화

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- PATCH /api/my/profile/withdraw
- Authorization: Bearer {access_token}
- 상태 관리: ACTIVE vs WITHDRAWN

- [신규 가입]
  카카오 로그인 → User 생성 (ACTIVE) → JWT 발급
-  [정상 이용]
  JWT 인증 → 서비스 이용 (ACTIVE 상태만)
- [탈퇴]
  탈퇴 API → 상태 변경 (WITHDRAWN) + 토큰 삭제
- [재가입]
  카카오 로그인 → 기존 User 발견 → 상태 복구 (ACTIVE) → JWT 발급

## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="1070" height="248" alt="image" src="https://github.com/user-attachments/assets/ecdeee30-76aa-496d-a658-a0de7bb43146" />
<img width="1074" height="227" alt="image" src="https://github.com/user-attachments/assets/9876fa66-da76-4174-866e-b17ddfbfe76e" />
<img width="1074" height="224" alt="image" src="https://github.com/user-attachments/assets/7cc63a67-dff5-4d8c-a44f-342b461f8b27" />
