### PR TITLE
[Feat/#104] 나의 여행지 페이지 검색 기능 추가

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceSaveController.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/controller/PlaceSaveController.java
@@ -79,7 +79,18 @@ public class PlaceSaveController {
 
     @Operation(
             summary = "내 저장 목록 조회",
-            description = "현재 로그인 사용자의 저장 목록을 페이징으로 조회합니다.",
+            description = """
+                    현재 로그인 사용자의 저장 목록을 페이징으로 조회합니다.
+
+                    **검색 기능:**
+                    - `keyword`: 장소명으로 검색 (부분 일치, 대소문자 무관)
+                    - 검색어가 없으면 전체 목록 반환
+
+                    **예시:**
+                    - `/api/my/places?page=0&size=20` - 전체 목록 조회
+                    - `/api/my/places?keyword=경복궁` - "경복궁" 포함 장소만 조회
+                    - `/api/my/places?keyword=바다&page=0&size=10` - "바다" 검색 + 페이징
+                    """,
             security = @SecurityRequirement(name = "JWT TOKEN")
     )
     @ApiResponses({
@@ -90,9 +101,10 @@ public class PlaceSaveController {
     public ResponseEntity<ApiResponse<UserPlacePageResponseDto>> mySaved(
             @Parameter(hidden = true) @LoginUser User user,
             @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(value = "page", defaultValue = "0") int page,
-            @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "20") int size) {
+            @Parameter(description = "페이지 크기") @RequestParam(value = "size", defaultValue = "20") int size,
+            @Parameter(description = "장소명 검색어 (부분 일치)") @RequestParam(value = "keyword", required = false) String keyword) {
 
-        var result = userPlaceService.getMyPlaces(user.getUserId (), UserActionType.SAVE, page, size);
+        var result = userPlaceService.getMyPlaces(user.getUserId(), UserActionType.SAVE, page, size, keyword);
         return ResponseEntity.ok(ApiResponse.ok(result));
     }
 

--- a/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
+++ b/src/main/java/com/comma/soomteum/domain/userPlace/service/UserPlaceService.java
@@ -161,24 +161,34 @@ public class UserPlaceService {
     }
 
     @Transactional(readOnly = true)
-    public UserPlacePageResponseDto getMyPlaces(Long userId, UserActionType type, int page, int size) {
+    public UserPlacePageResponseDto getMyPlaces(Long userId, UserActionType type, int page, int size, String keyword) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         var pageable = org.springframework.data.domain.PageRequest.of(page, size);
         var pageResult = userPlaceRepository.findByUser_UserIdAndType(userId, type, pageable);
 
-        var items = pageResult.getContent().stream().map(up -> {
-            var place = up.getPlace();
-            return UserPlaceItemDto.builder()
-                    .cnctrLevel(place.getCnctrLevel())
-                    .contentId(place.getContentId())
-                    .placeName(place.getName())
-                    .likeCount(place.getLikeCount())
-                    .themeName(place.getTheme() != null ? place.getTheme().getName() : null)
-                    .savedAt(up.getCreatedAt())
-                    .build();
-        }).toList();
+        var items = pageResult.getContent().stream()
+                // 검색 필터링
+                .filter(up -> {
+                    if (keyword == null || keyword.isBlank()) {
+                        return true;  // 검색어 없으면 모두 통과
+                    }
+                    String placeName = up.getPlace().getName();
+                    return placeName != null && placeName.toLowerCase()
+                            .contains(keyword.toLowerCase());
+                })
+                .map(up -> {
+                    var place = up.getPlace();
+                    return UserPlaceItemDto.builder()
+                            .cnctrLevel(place.getCnctrLevel())
+                            .contentId(place.getContentId())
+                            .placeName(place.getName())
+                            .likeCount(place.getLikeCount())
+                            .themeName(place.getTheme() != null ? place.getTheme().getName() : null)
+                            .savedAt(up.getCreatedAt())
+                            .build();
+                }).toList();
 
         return UserPlacePageResponseDto.of(
                 items,


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #104 

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 나의 여행지 페이지 검색 기능 추가

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 검색 기능
  - keyword 파라미터 추가
  - 장소명(placeName)으로 대소문자 구분 없이 부분 일치 검색
  - 검색어가 없으면 전체 결과 반환

- 동작 방식
  1. DB에서 사용자의 저장 목록을 페이징으로 조회
  2. 메모리에서 keyword로 필터링 (있는 경우)
  3. 필터링된 결과를 DTO로 변환하여 반환

## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="450" height="228" alt="image" src="https://github.com/user-attachments/assets/3f634108-9829-4e8f-8cac-1674363aa825" />


## 🚀 추후 개선 계획
현재 구현: Stream 필터링
- 구현이 간단하고 빠름
- 사용자당 저장 목록이 많지 않으면 성능 문제 없음

개선 계획: Repository Query 메서드
- DB 레벨에서 필터링 처리 → 대용량 데이터에서도 효율적
- 검색 조건 반영된 정확한 페이징 가능
- 현재는 검색 전에 페이징이 적용되므로, 검색 후 반환 개수가 페이지 크기보다 적을 수 있음