### PR TITLE
[Fix/#106] 로그인 실패 시 401 에러 반환

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/auth/annotation/LoginUserArgumentResolver.java
+++ b/src/main/java/com/comma/soomteum/domain/auth/annotation/LoginUserArgumentResolver.java
@@ -36,8 +36,8 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
 
         String token = jwtTokenManager.resolveToken(request);
         if (token == null || !jwtTokenManager.validateToken(token)) {
-            // 토큰이 없거나 유효하지 않을 경우, null을 반환하여 비로그인 상태로 처리
-            return null;
+            // 토큰이 없거나 유효하지 않을 경우, 401 에러 반환
+            throw new CustomException(ErrorCode.INVALID_LOGIN);
         }
 
         Long userId = jwtTokenManager.getUserIdFromToken(token);


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #106

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 로그인 실패 시 500 에러 대신 401 에러가 반환되도록 예외 처리 수정

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
- 수정 파일: LoginUserArgumentResolver.java (38–40행)

- 이전 동작
  - 토큰이 없거나 유효하지 않으면 null 반환
  - 이후 NullPointerException 발생 → 500 Internal Server Error 반환
- 변경 후 동작
  - 토큰이 없거나 유효하지 않을 경우
  → CustomException(ErrorCode.INVALID_LOGIN) 발생
  → 401 Unauthorized 에러 반환

- 결과
  - 유효하지 않은 토큰이거나 토큰 없이 요청 시
  - HTTP 상태 코드: 401 Unauthorized
  - 에러 코드: 401_008
  - 에러 메시지: "로그인이 필요합니다."
  - 프론트엔드에서 401 응답을 감지해 로그인 페이지 리다이렉트 등의 처리 가능
