### PR TITLE
[Fix/#99] 한적함 못 받아오는 에러 해결

### DIFF
--- a/src/main/java/com/comma/soomteum/domain/place/dto/KorService2Response.java
+++ b/src/main/java/com/comma/soomteum/domain/place/dto/KorService2Response.java
@@ -1,6 +1,7 @@
 package com.comma.soomteum.domain.place.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -54,9 +55,9 @@ public class KorService2Response {
         private String cat2;
         private String firstimage;
         private String dist;
-        @JacksonXmlProperty(localName = "areacode")
+        @JsonProperty("areacode")
         private String areaCode;
-        @JacksonXmlProperty(localName = "sigungucode")
+        @JsonProperty("sigungucode")
         private String sigunguCode;
         private Integer pageNo;
         private Integer numOfRows;


### PR DESCRIPTION
<!-- 제목 규칙 -->
<!-- [Type/{#이슈번호}] 작업내용 -->
<!-- 예시: [Feat/#20] 카카오 소셜 로그인 구현 -->

<!-- 리뷰어와 라벨을 꼭 적용해 주세요!-->

## 📌 연관 이슈
<!-- 이 PR과 연관된 이슈 번호를 적어주세요 -->
- close #99

## 🌱 PR 요약
<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
 한국관광공사 API 응답에서 areaCode, sigunguCode 필드가 null로 파싱되는 문제를 해결했습니다.

## 🛠 작업 내용
<!-- 구체적인 작업 내용을 적어주세요 -->
기존 문제: [TatsCnctr] 정확한 지역 코드 매칭 실패, area 코드만으로 재시도: area=null, sigungu=null
  - KorService2Response.LocationBasedListResponseDto에서 areaCode, sigunguCode 필드의 Jackson 어노테이션을 @JacksonXmlProperty에서 @JsonProperty로 변경
  - 한국관광공사 API가 JSON 응답을 반환하는데 XML용 어노테이션을 사용하여 필드 매핑이 실패하던 문제를 수정
  - 이를 통해 혼잡도 조회 서비스(TatsCnctrService.getCnctrRate)에서 올바른 지역 코드를 받아 처리할 수 있도록 개선
  
## 📸 상세 이미지
<!-- 기능 테스트 후 스크린샷을 남겨주세요 (ex. swagger) -->
<img width="759" height="437" alt="image" src="https://github.com/user-attachments/assets/7083d630-9160-4961-8bf2-162c23676c25" />
